### PR TITLE
Misc.getContextFor() checks if current session has a user to prevent error when execute in a scheduled event.

### DIFF
--- a/src/javasource/communitycommons/Misc.java
+++ b/src/javasource/communitycommons/Misc.java
@@ -267,8 +267,9 @@ public class Misc
 		if (username == null || username.isEmpty()) {
 			throw new RuntimeException("Assertion: No username provided");
 		}
-		
-		if (username.equals(context.getSession().getUser().getName()))
+
+        // Session does not have a user when it's a scheduled event.
+		if (context.getSession().getUser() != null && username.equals(context.getSession().getUser().getName()))
 		{
 			return context;
 		}


### PR DESCRIPTION
Calling executeMicroflowAsUser or related java actions from a scheduled event throws an exception because the Java code checks if the current user is equal to the target user. In a scheduled event there is no current user. I added a check for this to Misc.getContextFor() which fixes this problem.