### PR TITLE
Prevent cloning from non-existing objects

### DIFF
--- a/src/CommunityCommons/javasource/communitycommons/ORM.java
+++ b/src/CommunityCommons/javasource/communitycommons/ORM.java
@@ -102,8 +102,11 @@ public class ORM {
 					List<IMendixIdentifier> res = new ArrayList<IMendixIdentifier>();
 					for (IMendixIdentifier item : rs.getValue(ctx)) {
 						IMendixObject o = Core.retrieveId(ctx, item);
-						IMendixIdentifier refObj = getCloneOfObject(ctx, o, toskip, tokeep, revAssoc, skipEntities, skipModules, mappedObjects);
-						res.add(refObj);
+						// Do not try to clone a non-existing object
+						if (null != o) {
+							IMendixIdentifier refObj = getCloneOfObject(ctx, o, toskip, tokeep, revAssoc, skipEntities, skipModules, mappedObjects);
+							res.add(refObj);
+						}
 					}
 					tar.setValue(ctx, key, res);
 				} else if (m instanceof MendixAutoNumber) //skip autonumbers! Ticket 14893


### PR DESCRIPTION
If there is an orphaned relationship in a link table, do not try to get a clone of the object, as this will fail badly.
Please review and include in further revisions.
Thank you very much!