### PR TITLE
Added code to always generate lowercase letters in generateCommonLang…

### DIFF
--- a/src/CommunityCommons/javasource/communitycommons/StringUtils.java
+++ b/src/CommunityCommons/javasource/communitycommons/StringUtils.java
@@ -306,12 +306,14 @@ public class StringUtils {
 	// See https://www.baeldung.com/java-generate-secure-password
 	// Implementation inspired by https://github.com/eugenp/tutorials/tree/master/core-java-modules/core-java-string-apis (under MIT license)
 	private static String generateCommonLangPassword(int minLen, int maxLen, int noOfCapsAlpha, int noOfDigits, int noOfSplChars) {
+		int noOfLowerAlpha = minLen - noOfCapsAlpha - noOfDigits - noOfSplChars;
+		String lowerCaseLetters = RandomStringUtils.random(noOfLowerAlpha, 97, 122, true, true);
 		String upperCaseLetters = RandomStringUtils.random(noOfCapsAlpha, 65, 90, true, true);
 		String numbers = RandomStringUtils.randomNumeric(noOfDigits);
 		String specialChar = RandomStringUtils.random(noOfSplChars, 33, 47, false, false);
-		final int fixedNumber = noOfCapsAlpha + noOfDigits + noOfSplChars;
-		String totalChars = RandomStringUtils.randomAlphanumeric(minLen - fixedNumber, maxLen - fixedNumber);
+		String totalChars = RandomStringUtils.randomAlphanumeric(0, maxLen - minLen);
 		String combinedChars = upperCaseLetters
+			.concat(lowerCaseLetters)
 			.concat(numbers)
 			.concat(specialChar)
 			.concat(totalChars);

--- a/src/CommunityCommons/javasource/communitycommons/StringUtils.java
+++ b/src/CommunityCommons/javasource/communitycommons/StringUtils.java
@@ -297,8 +297,8 @@ public class StringUtils {
 		if (minLen > maxLen) {
 			throw new IllegalArgumentException("Min. Length > Max. Length!");
 		}
-		if ((noOfCAPSAlpha + noOfDigits + noOfSplChars) > minLen) {
-			throw new IllegalArgumentException("Min. Length should be atleast sum of (CAPS, DIGITS, SPL CHARS) Length!");
+		if ((noOfCAPSAlpha + noOfDigits + noOfSplChars + 1) > minLen) {
+			throw new IllegalArgumentException("Min. Length should be at least one more than sum of (CAPS, DIGITS, SPL CHARS) Length!");
 		}
 		return generateCommonLangPassword(minLen, maxLen, noOfCAPSAlpha, noOfDigits, noOfSplChars);
 	}


### PR DESCRIPTION
The error has nothing to do with the Apache Commons Lang3 library. It's caused by the code in the **generateCommonLangPassword** method of the **StringUtils** class. If you look at the code you can see that there is no guarantee that lowercase letters will be included in the random password. In practice, if you use the RandomStrongPassword Java Action to create a password and assign it to a System.User, every now and then it will fail to meet the password criteria and generate an error "Password does not meet password criteria: - Password should contain a lowercase letter."

I created this pull request to propose a possible solution. This solution requires no change to parameters for the RandomStrongPassword Java Action so developers can safely upgrade to the latest version and there will be no errors.

However, because the new code will always create at least 1 lowercase letter, the code that checks the requested number of characters and compares to the "Min length" parameter may generate a runtime error if the "Min length" is less than _or equal to_ the sum of "Nr of capitalized characters", "Nr of digits" and "Nr of special characters". The current code will pass it if the length is equal to the sum of the requested characters. In the browser, the user will just see "An error occurred" but in the log the error will be "Min. Length should be at least one more than sum of (CAPS, DIGITS, SPL CHARS) Length!". They must always make sure the "Min length" is at least one more than the number of caps, digits, and special characters so that at least one lowercase letter is included.

Once again, this is not fixed by using a newer (or older) version of the Apache Commons Lang3 module.

I have created a simple Mendix application on a free node to illustrate the problem and its solution. I created it with Studio Pro 9.1.1 and it uses the latest CommunityCommons module. It generates 100 passwords with the RandomStrongPassword Java Action and validates that they have a mix of uppercase and lowercase characters, special characters, and numbers. You can see for yourself how many fail to meet standard password criteria. It also creates 100 passwords using the fix in this pull request that always guarantees at least 1 lowercase letter and always meets standard password criteria. The application is here:

[https://randomstrongpasswordtest-sandbox.mxapps.io/](https://randomstrongpasswordtest-sandbox.mxapps.io/)

I would be happy to invite you to the Mendix project RandomStrongPasswordTest so you can see the code if you'd like but I think this will suffice to illustrate the problem and how to fix it.