### PR TITLE
[RTO-2959] Allow nulls for the XSSSanitize configuration

### DIFF
--- a/marketplace/release-notes/8.6.0.txt
+++ b/marketplace/release-notes/8.6.0.txt
@@ -1,0 +1,2 @@
+Allow null/empty values when configuring the SanitizerPolicies for the XSSSanitize class.
+

--- a/marketplace/release-notes/8.6.0.txt
+++ b/marketplace/release-notes/8.6.0.txt
@@ -1,2 +1,1 @@
-Allow null/empty values when configuring the SanitizerPolicies for the XSSSanitize class.
-
+Fixed regression introduced in 8.5.0 when configuring null/empty values as the SanitizerPolicies for the XSSSanitize class.

--- a/src/CommunityCommons/javasource/communitycommons/actions/XSSSanitize.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/XSSSanitize.java
@@ -13,18 +13,21 @@ import com.mendix.systemwideinterfaces.MendixRuntimeException;
 import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 import communitycommons.proxies.SanitizerPolicy;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Removes all potiential dangerous HTML from a string so that it can be safely displayed in a browser. 
+ * Removes all potential dangerous HTML from a string so that it can be safely displayed in a browser.
  * 
  * This function should be applied to all HTML which is displayed in the browser, and can be entered by (untrusted) users.
  * 
  * - HTML: The html to sanitize
- * - policy1... policy6: one or more values of SanitizerPolicy. You may leave these poliy parameters empty if you don't want to allow additional elements.
+ * - policy1... policy6: one or more values of SanitizerPolicy. You may leave these policy parameters empty if you don't want to allow additional elements.
  * 
  * BLOCKS: Allows common block elements including <p>, <h1>, etc.
  * FORMATTING: Allows common formatting elements including <b>, <i>, etc.
@@ -67,8 +70,7 @@ public class XSSSanitize extends CustomJavaAction<java.lang.String>
 			return "";
 		}
 
-		List<SanitizerPolicy> policyParams = List.of(policy1, policy2, policy3, policy4, policy5, policy6)
-			.stream()
+		List<SanitizerPolicy> policyParams = Stream.of(policy1, policy2, policy3, policy4, policy5, policy6)
 			.filter(Objects::nonNull)
 			.collect(Collectors.toList());
 


### PR DESCRIPTION
## Summary

Previously, nulls (or empty) would throw an exception during initialisation of an XSSSanitize instance. This is now resolved by using `Stream.of` instead of `List.of`, as the former allows **nulls**.

### Further Changes

 - Fixed some typos.