### PR TITLE
GetImageDimensions can crash Mendix app when processing high resolution images

### DIFF
--- a/src/CommunityCommons/javasource/communitycommons/actions/GetImageDimensions.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/GetImageDimensions.java
@@ -9,14 +9,17 @@
 
 package communitycommons.actions;
 
-import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 import com.mendix.core.Core;
 import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 import com.mendix.webui.CustomJavaAction;
 import communitycommons.proxies.ImageDimensions;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.Iterator;
 
 public class GetImageDimensions extends CustomJavaAction<IMendixObject>
 {
@@ -32,22 +35,39 @@ public class GetImageDimensions extends CustomJavaAction<IMendixObject>
 	@java.lang.Override
 	public IMendixObject executeAction() throws Exception
 	{
-		this.ImageParameter = __ImageParameter == null ? null : system.proxies.Image.initialize(getContext(), __ImageParameter);
+		this.ImageParameter = this.__ImageParameter == null ? null : system.proxies.Image.initialize(getContext(), __ImageParameter);
 
 		// BEGIN USER CODE
 		ImageDimensions imageDimensions = new ImageDimensions(getContext());
-		try (InputStream inputStream = Core.getImage(getContext(), this.ImageParameter.getMendixObject(), false)) {
-			BufferedImage bimg = ImageIO.read(inputStream);
-			imageDimensions.setHeight(bimg.getHeight());
-			imageDimensions.setWidth(bimg.getWidth());
-		}
 
-		return imageDimensions.getMendixObject();
+		try (InputStream inputStream = Core.getImage(getContext(), this.ImageParameter.getMendixObject(), false);
+			ImageInputStream imageStream = ImageIO.createImageInputStream(inputStream)) {
+			if(imageStream != null) {
+				Iterator<ImageReader> readers = ImageIO.getImageReaders(imageStream);
+				if (!readers.hasNext()) throw new IOException("Can't find a suitable imagereader for this image");;
+
+				ImageReader reader = readers.next();
+			  
+				try {
+					reader.setInput(imageStream);
+					int height = reader.getHeight(reader.getMinIndex());
+					int width = reader.getWidth(reader.getMinIndex());
+					imageDimensions.setHeight(height);
+					imageDimensions.setWidth(width);
+					return imageDimensions.getMendixObject();
+				} finally {
+					reader.dispose();
+				}
+			} else {
+				throw new IOException("Can't open a stream for this image");
+			}
+		}
 		// END USER CODE
 	}
 
 	/**
 	 * Returns a string representation of this action
+	 * @return a string representation of this action
 	 */
 	@java.lang.Override
 	public java.lang.String toString()


### PR DESCRIPTION
The current version of GetImageDimensions makes use of Java's BufferedImage, which loads the image uncompressed into memory. This can cause an out of memory exception using this java action with a a high resolution image. 
 
The new implementation is based on the stackoverflow post below and avoids loading the image uncompressed into memory.
https://stackoverflow.com/questions/672916/how-to-get-image-height-and-width-using-java 
