### PR TITLE
Modify RandomStrongPassword to always generate passwords with at least one lowercase letter

### DIFF
--- a/src/CommunityCommons/javasource/communitycommons/StringUtils.java
+++ b/src/CommunityCommons/javasource/communitycommons/StringUtils.java
@@ -293,8 +293,8 @@ public class StringUtils {
 		if (minLen > maxLen) {
 			throw new IllegalArgumentException("Min. Length > Max. Length!");
 		}
-		if ((noOfCAPSAlpha + noOfDigits + noOfSplChars) > minLen) {
-			throw new IllegalArgumentException("Min. Length should be atleast sum of (CAPS, DIGITS, SPL CHARS) Length!");
+		if ((noOfCAPSAlpha + noOfDigits + noOfSplChars + 1) > minLen) {
+			throw new IllegalArgumentException("Min. Length should be at least one more than the sum of (CAPS, DIGITS, SPL CHARS) Length!");
 		}
 		return generateCommonLangPassword(minLen, maxLen, noOfCAPSAlpha, noOfDigits, noOfSplChars);
 	}
@@ -302,16 +302,19 @@ public class StringUtils {
 	// See https://www.baeldung.com/java-generate-secure-password
 	// Implementation inspired by https://github.com/eugenp/tutorials/tree/master/core-java-modules/core-java-string-apis (under MIT license)
 	private static String generateCommonLangPassword(int minLen, int maxLen, int noOfCapsAlpha, int noOfDigits, int noOfSplChars) {
+		int noOfLowerAlpha = minLen - noOfCapsAlpha - noOfDigits - noOfSplChars;
+		String lowerCaseLetters = randomStringFromCharArray(noOfLowerAlpha, LOWERCASE_ALPHA.toCharArray());
 		String upperCaseLetters = randomStringFromCharArray(noOfCapsAlpha, UPPERCASE_ALPHA.toCharArray());
 		String numbers = randomStringFromCharArray(noOfDigits, DIGITS.toCharArray());
 		String specialChar = randomStringFromCharArray(noOfSplChars, SPECIAL.toCharArray());
 
-		final int fixedNumber = noOfCapsAlpha + noOfDigits + noOfSplChars;
+		final int fixedNumber = noOfCapsAlpha + noOfDigits + noOfSplChars + noOfLowerAlpha;
 		final int lowerBound = minLen - fixedNumber;
 		final int upperBound = maxLen - fixedNumber;
 		String totalChars = randomStringFromCharArray(lowerBound, upperBound, ALPHANUMERIC.toCharArray());
 
 		String combinedChars = upperCaseLetters
+			.concat(lowerCaseLetters)
 			.concat(numbers)
 			.concat(specialChar)
 			.concat(totalChars);


### PR DESCRIPTION
This is a proposed fix for [Issue 105](https://github.com/mendix/CommunityCommons/issues/105), "RandomStrongPassword sometimes doesn't generate lowercase letters".

As explained in the original issue thread, "The **generateCommonLangPassword** method in the **StringUtils** class of the CommunityCommons Java code never specifically generates lowercase characters so the random strings it generates sometimes don't have lowercase letters." The current Community Commons version (9.0.2) of the **generateCommonLangPassword** method to create a password for a System.User occasionally fails to meet the password criteria and generates the error: "Password does not meet password criteria: - Password should contain a lowercase letter."

The proposed solution modifies the **generateCommonLangPassword** method to always create passwords with at least 1 lowercase letter. The number of lowercase letters in the password is calculated by subtracting the total number of capitalized, digit, and special characters from min length. Min length must therefore be at least one _more_ than the sum of capitalized, digit, and special characters to ensure at least one lowercase letter. The **randomStrongPassword** method has been appropriately modified to log an error message if min length doesn't meet this criteria: "Min. Length should be at least one more than the sum of (CAPS, DIGITS, SPL CHARS) Length!"

We have created and published a simple Mendix app to illustrate the problem and its solution. The app uses Mendix version 9.18.2 and the latest version of the Community Commons module (9.0.2). It generates 100 passwords with the RandomStrongPassword Java Action and checks to see if they have a mix of uppercase and lowercase characters, special characters, and numbers. A significant number of the passwords created using this method don't include lowercase letters and therefore fail to meet standard password criteria. This is using the code in the current version of Community Commons.

The app also generates 100 passwords using the fixed code in this pull request that guarantees each password contains at least 1 lowercase letter. Using these two methods side by side effectively illustrates the current problem and proposed solution. [See the application here.](https://randomstrongpasswordtest-sandbox.mxapps.io/)

#105 