### PR TITLE
[RUN-3526] Cleanup XPath.java and add more functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ sourceSets {
 
 test {
     exclude 'unittesting/*'
+    testLogging.showStandardStreams true
 }
 
 task copyAllToUserlib(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ sourceSets {
 
 test {
     exclude 'unittesting/*'
-    testLogging.showStandardStreams true
 }
 
 task copyAllToUserlib(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compileOnly([group: 'com.mendix', name: 'public-api', version: "$mendixPublicApiVersion"])
 
     implementation(
-            [group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'],
+            [group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'],
             [group: 'com.googlecode.owasp-java-html-sanitizer', name: 'owasp-java-html-sanitizer', version: '20211018.2'],
             [group: 'commons-io', name: 'commons-io', version: '2.11.0'],
             [group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24'],

--- a/marketplace/release-notes/10.0.1.txt
+++ b/marketplace/release-notes/10.0.1.txt
@@ -1,0 +1,5 @@
+We added startsWith, endsWith, gte, lt and lte to XPath.java.
+
+We fixed gt in XPath.java. This function was using >= instead of the correct >.
+
+We updated the Guava dependency to 32.0.1.

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -749,10 +749,7 @@ public class XPath<T> {
     @Override
     public Boolean call() {
       try {
-        batchProcessor.onItem(XPath.createProxy(Core.createSystemContext(), self.proxyClass, item), index, count); // mwe:
-                                                                                                                   // hmm,
-                                                                                                                   // many
-                                                                                                                   // contexts..
+        batchProcessor.onItem(XPath.createProxy(Core.createSystemContext(), self.proxyClass, item), index, count);
         return true;
       } catch (Exception e) {
         throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", self.toString(),

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -254,7 +254,7 @@ public class XPath<T> {
     return compare(new Object[] { attr }, operator, value);
   }
 
-  public XPath<T> compare(String operator, Object[] pathAndValue) {
+  private XPath<T> compare(String operator, Object[] pathAndValue) {
     assertEven(pathAndValue);
     int lastIndex = pathAndValue.length - 1;
     return compare(Arrays.copyOf(pathAndValue, lastIndex), operator, pathAndValue[lastIndex]);

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -34,858 +34,852 @@ import com.mendix.systemwideinterfaces.core.IMendixIdentifier;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 
 public class XPath<T> {
-  /**
-   * Built-in tokens, see:
-   * https://docs.mendix.com/refguide/xpath-keywords-and-system-variables/
-   */
-
-  /* Keywords */
-  public static final String ID = "id";
-  public static final String NULL = "NULL";
-  public static final String Empty = "empty";
-
-  /* Object related */
-  public static final String CurrentUser = "[%CurrentUser%]";
-  public static final String CurrentObject = "[%CurrentObject%]";
-
-  /* Time related */
-  public static final String CurrentDateTime = "[%CurrentDateTime%]";
-  public static final String BeginOfCurrentMinute = "[%BeginOfCurrentMinute%]";
-  public static final String BeginOfCurrentMinuteUTC = "[%BeginOfCurrentMinuteUTC%]";
-  public static final String EndOfCurrentMinute = "[%EndOfCurrentMinute%]";
-  public static final String EndOfCurrentMinuteUTC = "[%EndOfCurrentMinuteUTC%]";
-  public static final String BeginOfCurrentHour = "[%BeginOfCurrentHour%]";
-  public static final String BeginOfCurrentHourUTC = "[%BeginOfCurrentHourUTC%]";
-  public static final String EndOfCurrentHour = "[%EndOfCurrentHour%]";
-  public static final String EndOfCurrentHourUTC = "[%EndOfCurrentHourUTC%]";
-  public static final String BeginOfCurrentDay = "[%BeginOfCurrentDay%]";
-  public static final String BeginOfCurrentDayUTC = "[%BeginOfCurrentDayUTC%]";
-  public static final String EndOfCurrentDay = "[%EndOfCurrentDay%]";
-  public static final String EndOfCurrentDayUTC = "[%EndOfCurrentDayUTC%]";
-  public static final String BeginOfYesterday = "[%BeginOfYesterday%]";
-  public static final String BeginOfYesterdayUTC = "[%BeginOfYesterdayUTC%]";
-  public static final String EndOfYesterday = "[%EndOfYesterday%]";
-  public static final String EndOfYesterdayUTC = "[%EndOfYesterdayUTC%]";
-  public static final String BeginOfTomorrow = "[%BeginOfTomorrow%]";
-  public static final String BeginOfTomorrowUTC = "[%BeginOfTomorrowUTC%]";
-  public static final String EndOfTomorrow = "[%EndOfTomorrow%]";
-  public static final String EndOfTomorrowUTC = "[%EndOfTomorrowUTC%]";
-  public static final String BeginOfCurrentWeek = "[%BeginOfCurrentWeek%]";
-  public static final String BeginOfCurrentWeekUTC = "[%BeginOfCurrentWeekUTC%]";
-  public static final String EndOfCurrentWeek = "[%EndOfCurrentWeek%]";
-  public static final String EndOfCurrentWeekUTC = "[%EndOfCurrentWeekUTC%]";
-  public static final String BeginOfCurrentMonth = "[%BeginOfCurrentMonth%]";
-  public static final String BeginOfCurrentMonthUTC = "[%BeginOfCurrentMonthUTC%]";
-  public static final String EndOfCurrentMonth = "[%EndOfCurrentMonth%]";
-  public static final String EndOfCurrentMonthUTC = "[%EndOfCurrentMonthUTC%]";
-  public static final String BeginOfCurrentYear = "[%BeginOfCurrentYear%]";
-  public static final String BeginOfCurrentYearUTC = "[%BeginOfCurrentYearUTC%]";
-  public static final String EndOfCurrentYear = "[%EndOfCurrentYear%]";
-  public static final String EndOfCurrentYearUTC = "[%EndOfCurrentYearUTC%]";
-
-  public static final String DayLength = "[%DayLength%]";
-  public static final String HourLength = "[%HourLength%]";
-  public static final String MinuteLength = "[%MinuteLength%]";
-  public static final String SecondLength = "[%SecondLength%]";
-  public static final String WeekLength = "[%WeekLength%]";
-  public static final String MonthLength = "[%MonthLength%]";
-  public static final String YearLength = "[%YearLength%]";
-
-  private String entity;
-  private int offset = 0;
-  private int limit = -1;
-  // important, linked map, insertion order is relevant!
-  private LinkedHashMap<String, String> sorting = new LinkedHashMap<String, String>();
-  private LinkedList<String> closeStack = new LinkedList<String>();
-  private StringBuilder builder = new StringBuilder();
-  private IContext context;
-  private Class<T> proxyClass;
-  // state property, indicates whether 'and' needs to be inserted before the next
-  // constraint
-  private boolean requiresBinOp = false;
-
-  public static XPath<IMendixObject> create(IContext c, String entityType) {
-    XPath<IMendixObject> res = new XPath<IMendixObject>(c, IMendixObject.class);
-    res.entity = entityType;
-    return res;
-  }
-
-  public static <U> XPath<U> create(IContext c, Class<U> proxyClass) {
-    return new XPath<U>(c, proxyClass);
-  }
-
-  private XPath(IContext c, Class<T> proxyClass) {
-    try {
-      if (proxyClass != IMendixObject.class)
-        entity = (String) proxyClass.getMethod("getType").invoke(null);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(
-          "Failed to determine entity type of proxy class. Did you provide a valid proxy class? '"
-              + proxyClass.getName() + "'");
-    }
-
-    this.proxyClass = proxyClass;
-    this.context = c;
-  }
-
-  private XPath<T> autoInsertAnd() {
-    if (requiresBinOp)
-      and();
-    return this;
-  }
-
-  private XPath<T> requireBinOp(boolean requires) {
-    requiresBinOp = requires;
-    return this;
-  }
-
-  public XPath<T> offset(int offset) {
-    if (offset < 0)
-      throw new IllegalArgumentException("Offset should not be negative");
-
-    this.offset = offset;
-    return this;
-  }
-
-  public XPath<T> limit(int limit) {
-    if (limit < -1 || limit == 0)
-      throw new IllegalArgumentException("Limit should be larger than zero or -1. ");
-
-    this.limit = limit;
-    return this;
-  }
-
-  public XPath<T> addSortingAsc(Object... sortparts) {
-    assertOdd(sortparts);
-    sorting.put(StringUtils.join(sortparts, '/'), "asc");
-    return this;
-  }
-
-  public XPath<T> addSortingDesc(Object... sortparts) {
-    sorting.put(StringUtils.join(sortparts, "/"), "desc");
-    return this;
-  }
-
-  public XPath<T> eq(Object attr, Object valuecomparison) {
-    return compare(attr, "=", valuecomparison);
-  }
-
-  public XPath<T> eq(Object... pathAndValue) {
-    return compare("=", pathAndValue);
-  }
-
-  public XPath<T> equalsIgnoreCase(Object attr, String value) {
-    // (contains(Name, $email) and length(Name) = length($email)
-    return subconstraint()
-        .contains(attr, value)
-        .and()
-        .append(" length(" + attr + ") = ").append(value == null ? "0" : valueToXPathValue(value.length()))
-        .close();
-  }
-
-  public XPath<T> notEq(Object attr, Object valuecomparison) {
-    return compare(attr, "!=", valuecomparison);
-  }
-
-  public XPath<T> notEq(Object... pathAndValue) {
-    return compare("!=", pathAndValue);
-  }
-
-  public XPath<T> gt(Object attr, Object valuecomparison) {
-    return compare(attr, ">", valuecomparison);
-  }
-
-  public XPath<T> gt(Object... pathAndValue) {
-    return compare(">", pathAndValue);
-  }
-
-  public XPath<T> gte(Object attr, Object valuecomparison) {
-    return compare(attr, ">=", valuecomparison);
-  }
-
-  public XPath<T> gte(Object... pathAndValue) {
-    return compare(">=", pathAndValue);
-  }
-
-  public XPath<T> lt(Object attr, Object valuecomparison) {
-    return compare(attr, "<", valuecomparison);
-  }
-
-  public XPath<T> lt(Object... pathAndValue) {
-    return compare("<", pathAndValue);
-  }
-
-  public XPath<T> lte(Object attr, Object valuecomparison) {
-    return compare(attr, "<=", valuecomparison);
-  }
-
-  public XPath<T> lte(Object... pathAndValue) {
-    return compare("<=", pathAndValue);
-  }
-
-  public XPath<T> contains(Object attr, String value) {
-    return functionCall("contains", String.valueOf(attr), valueToXPathValue(value));
-  }
-
-  public XPath<T> startsWith(Object attr, String value) {
-    return functionCall("starts-with", String.valueOf(attr), valueToXPathValue(value));
-  }
-
-  public XPath<T> endsWith(Object attr, String value) {
-    return functionCall("ends-with", String.valueOf(attr), valueToXPathValue(value));
-  }
-
-  private XPath<T> functionCall(String functionName, String... args) {
-    autoInsertAnd();
-    append(" " + functionName + "(");
-
-    if (args.length > 0) {
-      append(args[0]);
-      for (int i = 1; i < args.length; i++) {
-        append(",");
-        append(args[i]);
-      }
-    }
-    append(") ");
-    return requireBinOp(true);
-  }
-
-  public XPath<T> compare(Object attr, String operator, Object value) {
-    return compare(new Object[] { attr }, operator, value);
-  }
-
-  private XPath<T> compare(String operator, Object[] pathAndValue) {
-    assertEven(pathAndValue);
-    int lastIndex = pathAndValue.length - 1;
-    return compare(Arrays.copyOf(pathAndValue, lastIndex), operator, pathAndValue[lastIndex]);
-  }
-
-  public XPath<T> compare(Object[] path, String operator, Object value) {
-    assertOdd(path);
-    autoInsertAnd().append(StringUtils.join(path, '/')).append(" ").append(operator).append(" ")
-        .append(valueToXPathValue(value));
-    return requireBinOp(true);
-  }
-
-  public XPath<T> hasReference(Object... path) {
-    assertEven(path); // Reference + entity type
-    autoInsertAnd().append(StringUtils.join(path, '/'));
-    return requireBinOp(true);
-  }
-
-  public XPath<T> subconstraint(Object... path) {
-    assertEven(path);
-    autoInsertAnd().append(StringUtils.join(path, '/')).append("[");
-    closeStack.push("]");
-    return requireBinOp(false);
-  }
-
-  public XPath<T> subconstraint() {
-    autoInsertAnd().append("(");
-    closeStack.push(")");
-    return requireBinOp(false);
-  }
-
-  public XPath<T> addConstraint() {
-    if (!closeStack.isEmpty() && !closeStack.peek().equals("]"))
-      throw new IllegalStateException("Cannot add a constraint while in the middle of something else..");
-
-    return append("][").requireBinOp(false);
-  }
-
-  public XPath<T> close() {
-    if (closeStack.isEmpty())
-      throw new IllegalStateException("XPathbuilder close stack is empty!");
-    append(closeStack.pop());
-    return requireBinOp(true);
-    // MWE: note that a close does not necessary require a binary operator, for
-    // example with two subsequent block([bla][boe]) constraints,
-    // but openening a binary constraint reset the flag, so that should be no issue
-  }
-
-  public XPath<T> or() {
-    if (!requiresBinOp)
-      throw new IllegalStateException("Received 'or' but no binary operator was expected");
-    return append(" or ").requireBinOp(false);
-  }
-
-  public XPath<T> and() {
-    if (!requiresBinOp)
-      throw new IllegalStateException("Received 'and' but no binary operator was expected");
-    return append(" and ").requireBinOp(false);
-  }
-
-  public XPath<T> not() {
-    autoInsertAnd();
-    closeStack.push(")");
-    return append(" not(").requireBinOp(false);
-  }
-
-  private void assertOdd(Object[] stuff) {
-    if (stuff == null || stuff.length == 0 || stuff.length % 2 == 0)
-      throw new IllegalArgumentException("Expected an odd number of xpath path parts");
-  }
-
-  private void assertEven(Object[] stuff) {
-    if (stuff == null || stuff.length == 0 || stuff.length % 2 == 1)
-      throw new IllegalArgumentException("Expected an even number of xpath path parts");
-  }
-
-  public XPath<T> append(String s) {
-    builder.append(s);
-    return this;
-  }
-
-  public String getXPath() {
-    if (builder.length() > 0)
-      return "//" + entity + "[" + builder + "]";
-    return "//" + entity;
-  }
-
-  private void assertEmptyStack() throws IllegalStateException {
-    if (!closeStack.isEmpty())
-      throw new IllegalStateException("Invalid xpath expression, not all items where closed");
-  }
-
-  public long count() throws CoreException {
-    assertEmptyStack();
-
-    return Core.retrieveXPathQueryAggregate(context, "count(" + getXPath() + ")");
-  }
-
-  public IMendixObject firstMendixObject() throws CoreException {
-    assertEmptyStack();
-
-    List<IMendixObject> result = Core.retrieveXPathQuery(context, getXPath(), 1, offset, sorting);
-    if (result.isEmpty())
-      return null;
-    return result.get(0);
-  }
-
-  public T first() throws CoreException {
-    return createProxy(context, proxyClass, firstMendixObject());
-  }
-
-  /**
-   * Given a set of attribute names and values, tries to find the first object
-   * that matches all conditions, or creates one
-   * 
-   * @param keysAndValues
-   * @return
-   * @throws CoreException
-   */
-  public T findOrCreateNoCommit(Object... keysAndValues) throws CoreException {
-    T res = findFirst(keysAndValues);
-
-    return res != null ? res : constructInstance(false, keysAndValues);
-  }
-
-  public T findOrCreate(Object... keysAndValues) throws CoreException {
-    T res = findFirst(keysAndValues);
-
-    return res != null ? res : constructInstance(true, keysAndValues);
-
-  }
-
-  public T findOrCreateSynchronized(Object... keysAndValues) throws CoreException, InterruptedException {
-    T res = findFirst(keysAndValues);
-
-    if (res != null) {
-      return res;
-    } else {
-      synchronized (Core.getMetaObject(entity)) {
-        IContext synchronizedContext = context.getSession().createContext().createSudoClone();
-        try {
-          synchronizedContext.startTransaction();
-          res = createProxy(synchronizedContext, proxyClass,
-              XPath.create(synchronizedContext, entity).findOrCreate(keysAndValues));
-          synchronizedContext.endTransaction();
-          return res;
-        } catch (CoreException e) {
-          if (synchronizedContext.isInTransaction()) {
-            synchronizedContext.rollbackTransaction();
-          }
-          throw e;
-        }
-      }
-    }
-  }
-
-  public T findFirst(Object... keysAndValues)
-      throws IllegalStateException, CoreException {
-    if (builder.length() > 0)
-      throw new IllegalStateException("FindFirst can only be used on XPath which do not have constraints already");
-
-    assertEven(keysAndValues);
-    for (int i = 0; i < keysAndValues.length; i += 2)
-      eq(keysAndValues[i], keysAndValues[i + 1]);
-
-    return first();
-  }
-
-  /**
-   * Creates one instance of the type of this XPath query, and initializes the
-   * provided attributes to the provided values.
-   * 
-   * @param keysAndValues AttributeName, AttributeValue, AttributeName2,
-   *                      AttributeValue2... list.
-   * @return
-   * @throws CoreException
-   */
-  public T constructInstance(boolean autoCommit, Object... keysAndValues) throws CoreException {
-    assertEven(keysAndValues);
-    IMendixObject newObj = Core.instantiate(context, entity);
-
-    for (int i = 0; i < keysAndValues.length; i += 2)
-      newObj.setValue(context, String.valueOf(keysAndValues[i]), toMemberValue(keysAndValues[i + 1]));
-
-    if (autoCommit)
-      Core.commit(context, newObj);
-
-    return createProxy(context, proxyClass, newObj);
-  }
-
-  /**
-   * Given a current collection of primitive values, checks if for each value in
-   * the collection an object in the database exists.
-   * It creates a new object if needed, and removes any superfluos objects in the
-   * database that are no longer in the collection.
-   * 
-   * @param currentCollection   The collection that act as reference for the
-   *                            objects that should be in this database in the
-   *                            end.
-   * @param comparisonAttribute The attribute that should store the value as
-   *                            decribed in the collection
-   * @param autoDelete          Automatically remove any superfluous objects form
-   *                            the database
-   * @param keysAndValues       Constraints that should hold for the set of
-   *                            objects that are deleted or created. Objects
-   *                            outside this constraint are not processed.
-   * 
-   * @return A pair of lists. The first list contains the newly created objects,
-   *         the second list contains the objects that (should be or are) removed.
-   * @throws CoreException
-   */
-  public <U> ImmutablePair<List<T>, List<T>> syncDatabaseWithCollection(Collection<U> currentCollection,
-      Object comparisonAttribute, boolean autoDelete, Object... keysAndValues) throws CoreException {
-    if (builder.length() > 0)
-      throw new IllegalStateException(
-          "syncDatabaseWithCollection can only be used on XPath which do not have constraints already");
-
-    List<T> added = new ArrayList<T>();
-    List<T> removed = new ArrayList<T>();
-
-    Set<U> col = new HashSet<U>(currentCollection);
-
-    for (int i = 0; i < keysAndValues.length; i += 2)
-      eq(keysAndValues[i], keysAndValues[i + 1]);
-
-    for (IMendixObject existingItem : allMendixObjects()) {
-      // Item is still available
-      if (col.remove(existingItem.getValue(context, String.valueOf(comparisonAttribute))))
-        continue;
-
-      // No longer available
-      removed.add(createProxy(context, proxyClass, existingItem));
-      if (autoDelete)
-        Core.delete(context, existingItem);
-    }
-
-    // Some items where not found in the database
-    for (U value : col) {
-
-      // In apache lang3, this would just be: ArrayUtils.addAll(keysAndValues,
-      // comparisonAttribute, value)
-      Object[] args = new Object[keysAndValues.length + 2];
-      for (int i = 0; i < keysAndValues.length; i++)
-        args[i] = keysAndValues[i];
-      args[keysAndValues.length] = comparisonAttribute;
-      args[keysAndValues.length + 1] = value;
-
-      T newItem = constructInstance(true, args);
-      added.add(newItem);
-    }
-
-    // Oké, stupid, Pair is also only available in apache lang3, so lets use a
-    // simple pair implementation for now
-    return ImmutablePair.of(added, removed);
-  }
-
-  public T firstOrWait(long timeoutMSecs) throws CoreException, InterruptedException {
-    IMendixObject result = null;
-
-    long start = System.currentTimeMillis();
-    int sleepamount = 200;
-    int loopcount = 0;
-
-    while (result == null) {
-      loopcount += 1;
-      result = firstMendixObject();
-
-      long now = System.currentTimeMillis();
-
-      if (start + timeoutMSecs < now) // Time expired
-        break;
-
-      if (loopcount % 5 == 0)
-        sleepamount *= 1.5;
-
-      // not expired, wait a bit
-      if (result == null)
-        Thread.sleep(sleepamount);
-    }
-
-    return createProxy(context, proxyClass, result);
-  }
-
-  public List<IMendixObject> allMendixObjects() throws CoreException {
-    assertEmptyStack();
-
-    return Core.retrieveXPathQuery(context, getXPath(), limit, offset, sorting);
-  }
-
-  public List<T> all() throws CoreException {
-    List<T> res = new ArrayList<T>();
-    for (IMendixObject o : allMendixObjects())
-      res.add(createProxy(context, proxyClass, o));
-
-    return res;
-  }
-
-  @Override
-  public String toString() {
-    return getXPath();
-  }
-
-  /**
-   * 
-   * 
-   * Static utility functions
-   * 
-   * 
-   */
-
-  // cache for proxy constructors. Reflection is slow, so reuse as much as
-  // possible
-  private static Map<String, Method> initializers = new HashMap<String, Method>();
-
-  public static <T> List<T> createProxyList(IContext c, Class<T> proxieClass, List<IMendixObject> objects) {
-    List<T> res = new ArrayList<T>();
-    if (objects == null || objects.size() == 0)
-      return res;
-
-    for (IMendixObject o : objects)
-      res.add(createProxy(c, proxieClass, o));
-
-    return res;
-  }
-
-  public static <T> T createProxy(IContext c, Class<T> proxieClass, IMendixObject object) {
-    // Borrowed from nl.mweststrate.pages.MxQ package
-
-    if (object == null)
-      return null;
-
-    if (c == null || proxieClass == null)
-      throw new IllegalArgumentException("[CreateProxy] No context or proxieClass provided. ");
-
-    // jeuj, we expect IMendixObject's. Thats nice..
-    if (proxieClass == IMendixObject.class)
-      return proxieClass.cast(object); // .. since we can do a direct cast
-
-    try {
-      String entityType = object.getType();
-
-      if (!initializers.containsKey(entityType)) {
-
-        String[] entType = object.getType().split("\\.");
-        Class<?> realClass = Class.forName(entType[0].toLowerCase() + ".proxies." + entType[1]);
-
-        initializers.put(entityType, realClass.getMethod("initialize", IContext.class, IMendixObject.class));
-      }
-
-      // find constructor
-      Method m = initializers.get(entityType);
-
-      // create proxy object
-      Object result = m.invoke(null, c, object);
-
-      // cast, but check first is needed because the actual type might be a subclass
-      // of the requested type
-      if (!proxieClass.isAssignableFrom(result.getClass()))
-        throw new IllegalArgumentException("The type of the object ('" + object.getType()
-            + "') is not (a subclass) of '" + proxieClass.getName() + "'");
-
-      T proxie = proxieClass.cast(result);
-      return proxie;
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to instantiate proxie: " + e.getMessage(), e);
-    }
-  }
-
-  public static String valueToXPathValue(Object value) {
-    if (value == null)
-      return NULL;
-
-    // Complex objects
-    if (value instanceof IMendixIdentifier)
-      return "'" + String.valueOf(((IMendixIdentifier) value).toLong()) + "'";
-    if (value instanceof IMendixObject)
-      return valueToXPathValue(((IMendixObject) value).getId());
-    if (value instanceof List<?>)
-      throw new IllegalArgumentException("List based values are not supported!");
-
-    // Primitives
-    if (value instanceof Date)
-      return String.valueOf(((Date) value).getTime());
-    if (value instanceof Long || value instanceof Integer)
-      return String.valueOf(value);
-    if (value instanceof Double || value instanceof Float) {
-      // make sure xpath understands our number formatting
-      NumberFormat format = NumberFormat.getNumberInstance(Locale.ENGLISH);
-      format.setMaximumFractionDigits(10);
-      format.setGroupingUsed(false);
-      return format.format(value);
-    }
-    if (value instanceof Boolean) {
-      return value.toString() + "()"; // xpath boolean, you know..
-    }
-    if (value instanceof String) {
-      return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
-    }
-
-    // Object, assume its a proxy and deproxiefy
-    try {
-      IMendixObject mo = proxyToMendixObject(value);
-      return valueToXPathValue(mo);
-    } catch (NoSuchMethodException e) {
-      // This is O.K. just not a proxy object...
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to retrieve MendixObject from proxy: " + e.getMessage(), e);
-    }
-
-    // assume some string representation
-    return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
-  }
-
-  public static IMendixObject proxyToMendixObject(Object value)
-      throws NoSuchMethodException, SecurityException, IllegalAccessException,
-      IllegalArgumentException, InvocationTargetException {
-    Method m = value.getClass().getMethod("getMendixObject");
-    IMendixObject mo = (IMendixObject) m.invoke(value);
-    return mo;
-  }
-
-  public static <T> List<IMendixObject> proxyListToMendixObjectList(
-      List<T> objects) throws SecurityException, IllegalArgumentException, NoSuchMethodException,
-      IllegalAccessException, InvocationTargetException {
-    ArrayList<IMendixObject> res = new ArrayList<IMendixObject>(objects.size());
-    for (T i : objects)
-      res.add(proxyToMendixObject(i));
-    return res;
-  }
-
-  public static Object toMemberValue(Object value) {
-    if (value == null)
-      return null;
-
-    // Complex objects
-    if (value instanceof IMendixIdentifier)
-      return value;
-    if (value instanceof IMendixObject)
-      return ((IMendixObject) value).getId();
-
-    if (value instanceof List<?>)
-      throw new IllegalArgumentException("List based values are not supported!");
-
-    // Primitives
-    if (value instanceof Date
-        || value instanceof Long
-        || value instanceof Integer
-        || value instanceof Double
-        || value instanceof Float
-        || value instanceof Boolean
-        || value instanceof String) {
-      return value;
-    }
-
-    if (value.getClass().isEnum())
-      return value.toString();
-
-    // Object, assume its a proxy and deproxiefy
-    try {
-      Method m = value.getClass().getMethod("getMendixObject");
-      IMendixObject mo = (IMendixObject) m.invoke(value);
-      return toMemberValue(mo);
-    } catch (NoSuchMethodException e) {
-      // This is O.K. just not a proxy object...
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to convert object to IMendixMember compatible value '" + value + "': " + e.getMessage(), e);
-    }
-
-    throw new RuntimeException("Failed to convert object to IMendixMember compatible value: " + value);
-  }
-
-  public static interface IBatchProcessor<T> {
-    public void onItem(T item, long offset, long total) throws Exception;
-  }
-
-  private static final class ParallelJobRunner<T> implements Callable<Boolean> {
-    private final XPath<T> self;
-    private final IBatchProcessor<T> batchProcessor;
-    private final IMendixObject item;
-    private long index;
-    private long count;
-
-    ParallelJobRunner(XPath<T> self, IBatchProcessor<T> batchProcessor, IMendixObject item, long index, long count) {
-      this.self = self;
-      this.batchProcessor = batchProcessor;
-      this.item = item;
-      this.index = index;
-      this.count = count;
-    }
-
-    @Override
-    public Boolean call() {
-      try {
-        batchProcessor.onItem(XPath.createProxy(Core.createSystemContext(), self.proxyClass, item), index, count);
-        return true;
-      } catch (Exception e) {
-        throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", self.toString(),
-            self.offset, e.getMessage()), e);
-      }
-    }
-  }
-
-  /**
-   * Retreives all items in this xpath query in batches of a limited size.
-   * Not that this function does not start a new transaction for all the batches,
-   * rather, it just limits the number of objects being retrieved and kept in
-   * memory at the same time.
-   * 
-   * So it only batches the retrieve process, not the optional manipulations done
-   * in the onItem method.
-   * 
-   * @param batchsize
-   * @param batchProcessor
-   * @throws CoreException
-   */
-  public void batch(int batchsize, IBatchProcessor<T> batchProcessor) throws CoreException {
-    if (sorting.isEmpty())
-      addSortingAsc(XPath.ID);
-
-    final long itemcount = count();
-
-    int baseoffset = offset;
-    int baselimit = limit;
-
-    boolean useBaseLimit = baselimit > -1;
-
-    offset(baseoffset);
-    List<T> data;
-
-    long i = 0;
-
-    do {
-      int newlimit = useBaseLimit ? Math.min(batchsize, baseoffset + baselimit - offset) : batchsize;
-      if (newlimit == 0)
-        break; // where done, no more data is needed
-
-      limit(newlimit);
-      data = all();
-
-      for (T item : data) {
-        i += 1;
-        try {
-          batchProcessor.onItem(item, i, Math.max(i, itemcount));
-        } catch (Exception e) {
-          throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", this,
-              offset, e.getMessage()), e);
-        }
-      }
-
-      offset(offset + data.size());
-    } while (data.size() > 0);
-  }
-
-  /**
-   * Batch with parallelization.
-   * 
-   * IMPORTANT NOTE: DO NOT USE THE CONTEXT OF THE XPATH OBJECT ITSELF INSIDE THE
-   * BATCH PROCESSOR!
-   * 
-   * Instead, use: Item.getContext(); !!
-   * 
-   * 
-   * @param batchsize
-   * @param threads
-   * @param batchProcessor
-   * @throws CoreException
-   * @throws InterruptedException
-   * @throws ExecutionException
-   */
-  public void batch(int batchsize, int threads, final IBatchProcessor<T> batchProcessor)
-      throws CoreException, InterruptedException, ExecutionException {
-    if (sorting.isEmpty())
-      addSortingAsc(XPath.ID);
-
-    ExecutorService pool = Executors.newFixedThreadPool(threads);
-
-    final long itemcount = count();
-
-    int progress = 0;
-    List<Future<?>> futures = new ArrayList<Future<?>>(batchsize); // no need to synchronize
-
-    offset(0);
-    limit(batchsize);
-
-    List<IMendixObject> data = allMendixObjects();
-
-    while (data.size() > 0) {
-      for (final IMendixObject item : data) {
-        futures.add(pool.submit(new ParallelJobRunner<T>(this, batchProcessor, item, progress, itemcount)));
-        progress += 1;
-      }
-
-      while (!futures.isEmpty())
-        futures.remove(0).get(); // wait for all futures before proceeding to next iteration
-
-      offset(offset + data.size());
-      data = allMendixObjects();
-    }
-
-    if (pool.shutdownNow().size() > 0)
-      throw new IllegalStateException("Not all tasks where finished!");
-  }
-
-  public static Class<?> getProxyClassForEntityName(String entityname) {
-    {
-      String[] parts = entityname.split("\\.");
-      try {
-        return Class.forName(parts[0].toLowerCase() + ".proxies." + parts[1]);
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException("Cannot find class for entity: " + entityname + ": " + e.getMessage(), e);
-      }
-    }
-  }
-
-  public boolean deleteAll() throws CoreException {
-    limit(1000);
-    List<IMendixObject> objs = allMendixObjects();
-    while (!objs.isEmpty()) {
-      if (!Core.delete(context, objs.toArray(new IMendixObject[objs.size()])))
-        return false; // TODO: throw?
-
-      objs = allMendixObjects();
-    }
-    return true;
-  }
-
-  // Implement our own ESCAPE_XML because the original got deprecated and we
-  // originally translated only a very small
-  // subset of characters.
-  private static final CharSequenceTranslator ESCAPE_XML = new AggregateTranslator(
-      new LookupTranslator(EntityArrays.BASIC_ESCAPE),
-      new LookupTranslator(EntityArrays.APOS_ESCAPE));
+	/**
+	 * Built-in tokens, see:
+	 * https://docs.mendix.com/refguide/xpath-keywords-and-system-variables/
+	 */
+
+	/* Keywords */
+	public static final String ID = "id";
+	public static final String NULL = "NULL";
+	public static final String Empty = "empty";
+
+	/* Object related */
+	public static final String CurrentUser = "[%CurrentUser%]";
+	public static final String CurrentObject = "[%CurrentObject%]";
+
+	/* Time related */
+	public static final String CurrentDateTime = "[%CurrentDateTime%]";
+	public static final String BeginOfCurrentMinute = "[%BeginOfCurrentMinute%]";
+	public static final String BeginOfCurrentMinuteUTC = "[%BeginOfCurrentMinuteUTC%]";
+	public static final String EndOfCurrentMinute = "[%EndOfCurrentMinute%]";
+	public static final String EndOfCurrentMinuteUTC = "[%EndOfCurrentMinuteUTC%]";
+	public static final String BeginOfCurrentHour = "[%BeginOfCurrentHour%]";
+	public static final String BeginOfCurrentHourUTC = "[%BeginOfCurrentHourUTC%]";
+	public static final String EndOfCurrentHour = "[%EndOfCurrentHour%]";
+	public static final String EndOfCurrentHourUTC = "[%EndOfCurrentHourUTC%]";
+	public static final String BeginOfCurrentDay = "[%BeginOfCurrentDay%]";
+	public static final String BeginOfCurrentDayUTC = "[%BeginOfCurrentDayUTC%]";
+	public static final String EndOfCurrentDay = "[%EndOfCurrentDay%]";
+	public static final String EndOfCurrentDayUTC = "[%EndOfCurrentDayUTC%]";
+	public static final String BeginOfYesterday = "[%BeginOfYesterday%]";
+	public static final String BeginOfYesterdayUTC = "[%BeginOfYesterdayUTC%]";
+	public static final String EndOfYesterday = "[%EndOfYesterday%]";
+	public static final String EndOfYesterdayUTC = "[%EndOfYesterdayUTC%]";
+	public static final String BeginOfTomorrow = "[%BeginOfTomorrow%]";
+	public static final String BeginOfTomorrowUTC = "[%BeginOfTomorrowUTC%]";
+	public static final String EndOfTomorrow = "[%EndOfTomorrow%]";
+	public static final String EndOfTomorrowUTC = "[%EndOfTomorrowUTC%]";
+	public static final String BeginOfCurrentWeek = "[%BeginOfCurrentWeek%]";
+	public static final String BeginOfCurrentWeekUTC = "[%BeginOfCurrentWeekUTC%]";
+	public static final String EndOfCurrentWeek = "[%EndOfCurrentWeek%]";
+	public static final String EndOfCurrentWeekUTC = "[%EndOfCurrentWeekUTC%]";
+	public static final String BeginOfCurrentMonth = "[%BeginOfCurrentMonth%]";
+	public static final String BeginOfCurrentMonthUTC = "[%BeginOfCurrentMonthUTC%]";
+	public static final String EndOfCurrentMonth = "[%EndOfCurrentMonth%]";
+	public static final String EndOfCurrentMonthUTC = "[%EndOfCurrentMonthUTC%]";
+	public static final String BeginOfCurrentYear = "[%BeginOfCurrentYear%]";
+	public static final String BeginOfCurrentYearUTC = "[%BeginOfCurrentYearUTC%]";
+	public static final String EndOfCurrentYear = "[%EndOfCurrentYear%]";
+	public static final String EndOfCurrentYearUTC = "[%EndOfCurrentYearUTC%]";
+
+	public static final String DayLength = "[%DayLength%]";
+	public static final String HourLength = "[%HourLength%]";
+	public static final String MinuteLength = "[%MinuteLength%]";
+	public static final String SecondLength = "[%SecondLength%]";
+	public static final String WeekLength = "[%WeekLength%]";
+	public static final String MonthLength = "[%MonthLength%]";
+	public static final String YearLength = "[%YearLength%]";
+
+	private String entity;
+	private int offset = 0;
+	private int limit = -1;
+	// important, linked map, insertion order is relevant!
+	private LinkedHashMap<String, String> sorting = new LinkedHashMap<String, String>();
+	private LinkedList<String> closeStack = new LinkedList<String>();
+	private StringBuilder builder = new StringBuilder();
+	private IContext context;
+	private Class<T> proxyClass;
+	// state property, indicates whether 'and' needs to be inserted before the next
+	// constraint
+	private boolean requiresBinOp = false;
+
+	public static XPath<IMendixObject> create(IContext c, String entityType) {
+		XPath<IMendixObject> res = new XPath<IMendixObject>(c, IMendixObject.class);
+		res.entity = entityType;
+		return res;
+	}
+
+	public static <U> XPath<U> create(IContext c, Class<U> proxyClass) {
+		return new XPath<U>(c, proxyClass);
+	}
+
+	private XPath(IContext c, Class<T> proxyClass) {
+		try {
+			if (proxyClass != IMendixObject.class)
+				entity = (String) proxyClass.getMethod("getType").invoke(null);
+		} catch (Exception e) {
+			throw new IllegalArgumentException(
+				"Failed to determine entity type of proxy class. Did you provide a valid proxy class? '"
+					+ proxyClass.getName() + "'");
+		}
+
+		this.proxyClass = proxyClass;
+		this.context = c;
+	}
+
+	private XPath<T> autoInsertAnd() {
+		if (requiresBinOp)
+			and();
+		return this;
+	}
+
+	private XPath<T> requireBinOp(boolean requires) {
+		requiresBinOp = requires;
+		return this;
+	}
+
+	public XPath<T> offset(int offset) {
+		if (offset < 0)
+			throw new IllegalArgumentException("Offset should not be negative");
+
+		this.offset = offset;
+		return this;
+	}
+
+	public XPath<T> limit(int limit) {
+		if (limit < -1 || limit == 0)
+			throw new IllegalArgumentException("Limit should be larger than zero or -1. ");
+
+		this.limit = limit;
+		return this;
+	}
+
+	public XPath<T> addSortingAsc(Object... sortparts) {
+		assertOdd(sortparts);
+		sorting.put(StringUtils.join(sortparts, '/'), "asc");
+		return this;
+	}
+
+	public XPath<T> addSortingDesc(Object... sortparts) {
+		sorting.put(StringUtils.join(sortparts, "/"), "desc");
+		return this;
+	}
+
+	public XPath<T> eq(Object attr, Object valuecomparison) {
+		return compare(attr, "=", valuecomparison);
+	}
+
+	public XPath<T> eq(Object... pathAndValue) {
+		return compare("=", pathAndValue);
+	}
+
+	public XPath<T> equalsIgnoreCase(Object attr, String value) {
+		// (contains(Name, $email) and length(Name) = length($email)
+		return subconstraint()
+			.contains(attr, value)
+			.and()
+			.append(" length(" + attr + ") = ").append(value == null ? "0" : valueToXPathValue(value.length()))
+			.close();
+	}
+
+	public XPath<T> notEq(Object attr, Object valuecomparison) {
+		return compare(attr, "!=", valuecomparison);
+	}
+
+	public XPath<T> notEq(Object... pathAndValue) {
+		return compare("!=", pathAndValue);
+	}
+
+	public XPath<T> gt(Object attr, Object valuecomparison) {
+		return compare(attr, ">", valuecomparison);
+	}
+
+	public XPath<T> gt(Object... pathAndValue) {
+		return compare(">", pathAndValue);
+	}
+
+	public XPath<T> gte(Object attr, Object valuecomparison) {
+		return compare(attr, ">=", valuecomparison);
+	}
+
+	public XPath<T> gte(Object... pathAndValue) {
+		return compare(">=", pathAndValue);
+	}
+
+	public XPath<T> lt(Object attr, Object valuecomparison) {
+		return compare(attr, "<", valuecomparison);
+	}
+
+	public XPath<T> lt(Object... pathAndValue) {
+		return compare("<", pathAndValue);
+	}
+
+	public XPath<T> lte(Object attr, Object valuecomparison) {
+		return compare(attr, "<=", valuecomparison);
+	}
+
+	public XPath<T> lte(Object... pathAndValue) {
+		return compare("<=", pathAndValue);
+	}
+
+	public XPath<T> contains(Object attr, String value) {
+		return functionCall("contains", String.valueOf(attr), valueToXPathValue(value));
+	}
+
+	public XPath<T> startsWith(Object attr, String value) {
+		return functionCall("starts-with", String.valueOf(attr), valueToXPathValue(value));
+	}
+
+	public XPath<T> endsWith(Object attr, String value) {
+		return functionCall("ends-with", String.valueOf(attr), valueToXPathValue(value));
+	}
+
+	private XPath<T> functionCall(String functionName, String... args) {
+		autoInsertAnd();
+		append(" " + functionName + "(");
+
+		if (args.length > 0) {
+			append(args[0]);
+			for (int i = 1; i < args.length; i++) {
+				append(",");
+				append(args[i]);
+			}
+		}
+		append(") ");
+		return requireBinOp(true);
+	}
+
+	public XPath<T> compare(Object attr, String operator, Object value) {
+		return compare(new Object[] { attr }, operator, value);
+	}
+
+	private XPath<T> compare(String operator, Object[] pathAndValue) {
+		assertEven(pathAndValue);
+		int lastIndex = pathAndValue.length - 1;
+		return compare(Arrays.copyOf(pathAndValue, lastIndex), operator, pathAndValue[lastIndex]);
+	}
+
+	public XPath<T> compare(Object[] path, String operator, Object value) {
+		assertOdd(path);
+		autoInsertAnd().append(StringUtils.join(path, '/')).append(" ").append(operator).append(" ")
+			.append(valueToXPathValue(value));
+		return requireBinOp(true);
+	}
+
+	public XPath<T> hasReference(Object... path) {
+		assertEven(path); // Reference + entity type
+		autoInsertAnd().append(StringUtils.join(path, '/'));
+		return requireBinOp(true);
+	}
+
+	public XPath<T> subconstraint(Object... path) {
+		assertEven(path);
+		autoInsertAnd().append(StringUtils.join(path, '/')).append("[");
+		closeStack.push("]");
+		return requireBinOp(false);
+	}
+
+	public XPath<T> subconstraint() {
+		autoInsertAnd().append("(");
+		closeStack.push(")");
+		return requireBinOp(false);
+	}
+
+	public XPath<T> addConstraint() {
+		if (!closeStack.isEmpty() && !closeStack.peek().equals("]"))
+			throw new IllegalStateException("Cannot add a constraint while in the middle of something else..");
+
+		return append("][").requireBinOp(false);
+	}
+
+	public XPath<T> close() {
+		if (closeStack.isEmpty())
+			throw new IllegalStateException("XPathbuilder close stack is empty!");
+		append(closeStack.pop());
+		return requireBinOp(true);
+		// MWE: note that a close does not necessary require a binary operator, for
+		// example with two subsequent block([bla][boe]) constraints,
+		// but openening a binary constraint reset the flag, so that should be no issue
+	}
+
+	public XPath<T> or() {
+		if (!requiresBinOp)
+			throw new IllegalStateException("Received 'or' but no binary operator was expected");
+		return append(" or ").requireBinOp(false);
+	}
+
+	public XPath<T> and() {
+		if (!requiresBinOp)
+			throw new IllegalStateException("Received 'and' but no binary operator was expected");
+		return append(" and ").requireBinOp(false);
+	}
+
+	public XPath<T> not() {
+		autoInsertAnd();
+		closeStack.push(")");
+		return append(" not(").requireBinOp(false);
+	}
+
+	private void assertOdd(Object[] stuff) {
+		if (stuff == null || stuff.length == 0 || stuff.length % 2 == 0)
+			throw new IllegalArgumentException("Expected an odd number of xpath path parts");
+	}
+
+	private void assertEven(Object[] stuff) {
+		if (stuff == null || stuff.length == 0 || stuff.length % 2 == 1)
+			throw new IllegalArgumentException("Expected an even number of xpath path parts");
+	}
+
+	public XPath<T> append(String s) {
+		builder.append(s);
+		return this;
+	}
+
+	public String getXPath() {
+		if (builder.length() > 0)
+			return "//" + entity + "[" + builder + "]";
+		return "//" + entity;
+	}
+
+	private void assertEmptyStack() throws IllegalStateException {
+		if (!closeStack.isEmpty())
+			throw new IllegalStateException("Invalid xpath expression, not all items where closed");
+	}
+
+	public long count() throws CoreException {
+		assertEmptyStack();
+
+		return Core.retrieveXPathQueryAggregate(context, "count(" + getXPath() + ")");
+	}
+
+	public IMendixObject firstMendixObject() throws CoreException {
+		assertEmptyStack();
+
+		List<IMendixObject> result = Core.retrieveXPathQuery(context, getXPath(), 1, offset, sorting);
+		if (result.isEmpty())
+			return null;
+		return result.get(0);
+	}
+
+	public T first() throws CoreException {
+		return createProxy(context, proxyClass, firstMendixObject());
+	}
+
+	/**
+	 * Given a set of attribute names and values, tries to find the first object
+	 * that matches all conditions, or creates one
+	 *
+	 * @param keysAndValues
+	 * @return
+	 * @throws CoreException
+	 */
+	public T findOrCreateNoCommit(Object... keysAndValues) throws CoreException {
+		T res = findFirst(keysAndValues);
+
+		return res != null ? res : constructInstance(false, keysAndValues);
+	}
+
+	public T findOrCreate(Object... keysAndValues) throws CoreException {
+		T res = findFirst(keysAndValues);
+
+		return res != null ? res : constructInstance(true, keysAndValues);
+
+	}
+
+	public T findOrCreateSynchronized(Object... keysAndValues) throws CoreException, InterruptedException {
+		T res = findFirst(keysAndValues);
+
+		if (res != null) {
+			return res;
+		} else {
+			synchronized (Core.getMetaObject(entity)) {
+				IContext synchronizedContext = context.getSession().createContext().createSudoClone();
+				try {
+					synchronizedContext.startTransaction();
+					res = createProxy(synchronizedContext, proxyClass,
+						XPath.create(synchronizedContext, entity).findOrCreate(keysAndValues));
+					synchronizedContext.endTransaction();
+					return res;
+				} catch (CoreException e) {
+					if (synchronizedContext.isInTransaction()) {
+						synchronizedContext.rollbackTransaction();
+					}
+					throw e;
+				}
+			}
+		}
+	}
+
+	public T findFirst(Object... keysAndValues)
+		throws IllegalStateException, CoreException {
+		if (builder.length() > 0)
+			throw new IllegalStateException("FindFirst can only be used on XPath which do not have constraints already");
+
+		assertEven(keysAndValues);
+		for (int i = 0; i < keysAndValues.length; i += 2)
+			eq(keysAndValues[i], keysAndValues[i + 1]);
+
+		return first();
+	}
+
+	/**
+	 * Creates one instance of the type of this XPath query, and initializes the
+	 * provided attributes to the provided values.
+	 *
+	 * @param keysAndValues AttributeName, AttributeValue, AttributeName2,
+	 *                      AttributeValue2... list.
+	 * @return
+	 * @throws CoreException
+	 */
+	public T constructInstance(boolean autoCommit, Object... keysAndValues) throws CoreException {
+		assertEven(keysAndValues);
+		IMendixObject newObj = Core.instantiate(context, entity);
+
+		for (int i = 0; i < keysAndValues.length; i += 2)
+			newObj.setValue(context, String.valueOf(keysAndValues[i]), toMemberValue(keysAndValues[i + 1]));
+
+		if (autoCommit)
+			Core.commit(context, newObj);
+
+		return createProxy(context, proxyClass, newObj);
+	}
+
+	/**
+	 * Given a current collection of primitive values, checks if for each value in
+	 * the collection an object in the database exists.
+	 * It creates a new object if needed, and removes any superfluos objects in the
+	 * database that are no longer in the collection.
+	 *
+	 * @param currentCollection   The collection that act as reference for the
+	 *                            objects that should be in this database in the
+	 *                            end.
+	 * @param comparisonAttribute The attribute that should store the value as
+	 *                            decribed in the collection
+	 * @param autoDelete          Automatically remove any superfluous objects form
+	 *                            the database
+	 * @param keysAndValues       Constraints that should hold for the set of
+	 *                            objects that are deleted or created. Objects
+	 *                            outside this constraint are not processed.
+	 *
+	 * @return A pair of lists. The first list contains the newly created objects,
+	 *         the second list contains the objects that (should be or are) removed.
+	 * @throws CoreException
+	 */
+	public <U> ImmutablePair<List<T>, List<T>> syncDatabaseWithCollection(Collection<U> currentCollection,
+									      Object comparisonAttribute, boolean autoDelete, Object... keysAndValues) throws CoreException {
+		if (builder.length() > 0)
+			throw new IllegalStateException(
+				"syncDatabaseWithCollection can only be used on XPath which do not have constraints already");
+
+		List<T> added = new ArrayList<T>();
+		List<T> removed = new ArrayList<T>();
+
+		Set<U> col = new HashSet<U>(currentCollection);
+
+		for (int i = 0; i < keysAndValues.length; i += 2)
+			eq(keysAndValues[i], keysAndValues[i + 1]);
+
+		for (IMendixObject existingItem : allMendixObjects()) {
+			// Item is still available
+			if (col.remove(existingItem.getValue(context, String.valueOf(comparisonAttribute))))
+				continue;
+
+			// No longer available
+			removed.add(createProxy(context, proxyClass, existingItem));
+			if (autoDelete)
+				Core.delete(context, existingItem);
+		}
+
+		// Some items where not found in the database
+		for (U value : col) {
+
+			// In apache lang3, this would just be: ArrayUtils.addAll(keysAndValues,
+			// comparisonAttribute, value)
+			Object[] args = new Object[keysAndValues.length + 2];
+			for (int i = 0; i < keysAndValues.length; i++)
+				args[i] = keysAndValues[i];
+			args[keysAndValues.length] = comparisonAttribute;
+			args[keysAndValues.length + 1] = value;
+
+			T newItem = constructInstance(true, args);
+			added.add(newItem);
+		}
+
+		// Oké, stupid, Pair is also only available in apache lang3, so lets use a
+		// simple pair implementation for now
+		return ImmutablePair.of(added, removed);
+	}
+
+	public T firstOrWait(long timeoutMSecs) throws CoreException, InterruptedException {
+		IMendixObject result = null;
+
+		long start = System.currentTimeMillis();
+		int sleepamount = 200;
+		int loopcount = 0;
+
+		while (result == null) {
+			loopcount += 1;
+			result = firstMendixObject();
+
+			long now = System.currentTimeMillis();
+
+			if (start + timeoutMSecs < now) // Time expired
+				break;
+
+			if (loopcount % 5 == 0)
+				sleepamount *= 1.5;
+
+			// not expired, wait a bit
+			if (result == null)
+				Thread.sleep(sleepamount);
+		}
+
+		return createProxy(context, proxyClass, result);
+	}
+
+	public List<IMendixObject> allMendixObjects() throws CoreException {
+		assertEmptyStack();
+
+		return Core.retrieveXPathQuery(context, getXPath(), limit, offset, sorting);
+	}
+
+	public List<T> all() throws CoreException {
+		List<T> res = new ArrayList<T>();
+		for (IMendixObject o : allMendixObjects())
+			res.add(createProxy(context, proxyClass, o));
+
+		return res;
+	}
+
+	@Override
+	public String toString() {
+		return getXPath();
+	}
+
+	/* Static utility functions */
+
+	// Cache for proxy constructors. Reflection is slow, so reuse as much as
+	// possible
+	private static Map<String, Method> initializers = new HashMap<String, Method>();
+
+	public static <T> List<T> createProxyList(IContext c, Class<T> proxieClass, List<IMendixObject> objects) {
+		List<T> res = new ArrayList<T>();
+		if (objects == null || objects.size() == 0)
+			return res;
+
+		for (IMendixObject o : objects)
+			res.add(createProxy(c, proxieClass, o));
+
+		return res;
+	}
+
+	public static <T> T createProxy(IContext c, Class<T> proxieClass, IMendixObject object) {
+		// Borrowed from nl.mweststrate.pages.MxQ package
+
+		if (object == null)
+			return null;
+
+		if (c == null || proxieClass == null)
+			throw new IllegalArgumentException("[CreateProxy] No context or proxieClass provided. ");
+
+		// jeuj, we expect IMendixObject's. Thats nice..
+		if (proxieClass == IMendixObject.class)
+			return proxieClass.cast(object); // .. since we can do a direct cast
+
+		try {
+			String entityType = object.getType();
+
+			if (!initializers.containsKey(entityType)) {
+
+				String[] entType = object.getType().split("\\.");
+				Class<?> realClass = Class.forName(entType[0].toLowerCase() + ".proxies." + entType[1]);
+
+				initializers.put(entityType, realClass.getMethod("initialize", IContext.class, IMendixObject.class));
+			}
+
+			// find constructor
+			Method m = initializers.get(entityType);
+
+			// create proxy object
+			Object result = m.invoke(null, c, object);
+
+			// cast, but check first is needed because the actual type might be a subclass
+			// of the requested type
+			if (!proxieClass.isAssignableFrom(result.getClass()))
+				throw new IllegalArgumentException("The type of the object ('" + object.getType()
+					+ "') is not (a subclass) of '" + proxieClass.getName() + "'");
+
+			T proxie = proxieClass.cast(result);
+			return proxie;
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to instantiate proxie: " + e.getMessage(), e);
+		}
+	}
+
+	public static String valueToXPathValue(Object value) {
+		if (value == null)
+			return NULL;
+
+		// Complex objects
+		if (value instanceof IMendixIdentifier)
+			return "'" + String.valueOf(((IMendixIdentifier) value).toLong()) + "'";
+		if (value instanceof IMendixObject)
+			return valueToXPathValue(((IMendixObject) value).getId());
+		if (value instanceof List<?>)
+			throw new IllegalArgumentException("List based values are not supported!");
+
+		// Primitives
+		if (value instanceof Date)
+			return String.valueOf(((Date) value).getTime());
+		if (value instanceof Long || value instanceof Integer)
+			return String.valueOf(value);
+		if (value instanceof Double || value instanceof Float) {
+			// make sure xpath understands our number formatting
+			NumberFormat format = NumberFormat.getNumberInstance(Locale.ENGLISH);
+			format.setMaximumFractionDigits(10);
+			format.setGroupingUsed(false);
+			return format.format(value);
+		}
+		if (value instanceof Boolean) {
+			return value.toString() + "()"; // xpath boolean, you know..
+		}
+		if (value instanceof String) {
+			return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
+		}
+
+		// Object, assume its a proxy and deproxiefy
+		try {
+			IMendixObject mo = proxyToMendixObject(value);
+			return valueToXPathValue(mo);
+		} catch (NoSuchMethodException e) {
+			// This is O.K. just not a proxy object...
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to retrieve MendixObject from proxy: " + e.getMessage(), e);
+		}
+
+		// assume some string representation
+		return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
+	}
+
+	public static IMendixObject proxyToMendixObject(Object value)
+		throws NoSuchMethodException, SecurityException, IllegalAccessException,
+		IllegalArgumentException, InvocationTargetException {
+		Method m = value.getClass().getMethod("getMendixObject");
+		IMendixObject mo = (IMendixObject) m.invoke(value);
+		return mo;
+	}
+
+	public static <T> List<IMendixObject> proxyListToMendixObjectList(
+		List<T> objects) throws SecurityException, IllegalArgumentException, NoSuchMethodException,
+		IllegalAccessException, InvocationTargetException {
+		ArrayList<IMendixObject> res = new ArrayList<IMendixObject>(objects.size());
+		for (T i : objects)
+			res.add(proxyToMendixObject(i));
+		return res;
+	}
+
+	public static Object toMemberValue(Object value) {
+		if (value == null)
+			return null;
+
+		// Complex objects
+		if (value instanceof IMendixIdentifier)
+			return value;
+		if (value instanceof IMendixObject)
+			return ((IMendixObject) value).getId();
+
+		if (value instanceof List<?>)
+			throw new IllegalArgumentException("List based values are not supported!");
+
+		// Primitives
+		if (value instanceof Date
+			|| value instanceof Long
+			|| value instanceof Integer
+			|| value instanceof Double
+			|| value instanceof Float
+			|| value instanceof Boolean
+			|| value instanceof String) {
+			return value;
+		}
+
+		if (value.getClass().isEnum())
+			return value.toString();
+
+		// Object, assume its a proxy and deproxiefy
+		try {
+			Method m = value.getClass().getMethod("getMendixObject");
+			IMendixObject mo = (IMendixObject) m.invoke(value);
+			return toMemberValue(mo);
+		} catch (NoSuchMethodException e) {
+			// This is O.K. just not a proxy object...
+		} catch (Exception e) {
+			throw new RuntimeException(
+				"Failed to convert object to IMendixMember compatible value '" + value + "': " + e.getMessage(), e);
+		}
+
+		throw new RuntimeException("Failed to convert object to IMendixMember compatible value: " + value);
+	}
+
+	public static interface IBatchProcessor<T> {
+		public void onItem(T item, long offset, long total) throws Exception;
+	}
+
+	private static final class ParallelJobRunner<T> implements Callable<Boolean> {
+		private final XPath<T> self;
+		private final IBatchProcessor<T> batchProcessor;
+		private final IMendixObject item;
+		private long index;
+		private long count;
+
+		ParallelJobRunner(XPath<T> self, IBatchProcessor<T> batchProcessor, IMendixObject item, long index, long count) {
+			this.self = self;
+			this.batchProcessor = batchProcessor;
+			this.item = item;
+			this.index = index;
+			this.count = count;
+		}
+
+		@Override
+		public Boolean call() {
+			try {
+				batchProcessor.onItem(XPath.createProxy(Core.createSystemContext(), self.proxyClass, item), index, count);
+				return true;
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", self.toString(),
+					self.offset, e.getMessage()), e);
+			}
+		}
+	}
+
+	/**
+	 * Retreives all items in this xpath query in batches of a limited size.
+	 * Not that this function does not start a new transaction for all the batches,
+	 * rather, it just limits the number of objects being retrieved and kept in
+	 * memory at the same time.
+	 *
+	 * So it only batches the retrieve process, not the optional manipulations done
+	 * in the onItem method.
+	 *
+	 * @param batchsize
+	 * @param batchProcessor
+	 * @throws CoreException
+	 */
+	public void batch(int batchsize, IBatchProcessor<T> batchProcessor) throws CoreException {
+		if (sorting.isEmpty())
+			addSortingAsc(XPath.ID);
+
+		final long itemcount = count();
+
+		int baseoffset = offset;
+		int baselimit = limit;
+
+		boolean useBaseLimit = baselimit > -1;
+
+		offset(baseoffset);
+		List<T> data;
+
+		long i = 0;
+
+		do {
+			int newlimit = useBaseLimit ? Math.min(batchsize, baseoffset + baselimit - offset) : batchsize;
+			if (newlimit == 0)
+				break; // where done, no more data is needed
+
+			limit(newlimit);
+			data = all();
+
+			for (T item : data) {
+				i += 1;
+				try {
+					batchProcessor.onItem(item, i, Math.max(i, itemcount));
+				} catch (Exception e) {
+					throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", this,
+						offset, e.getMessage()), e);
+				}
+			}
+
+			offset(offset + data.size());
+		} while (data.size() > 0);
+	}
+
+	/**
+	 * Batch with parallelization.
+	 *
+	 * IMPORTANT NOTE: DO NOT USE THE CONTEXT OF THE XPATH OBJECT ITSELF INSIDE THE
+	 * BATCH PROCESSOR!
+	 *
+	 * Instead, use: Item.getContext(); !!
+	 *
+	 *
+	 * @param batchsize
+	 * @param threads
+	 * @param batchProcessor
+	 * @throws CoreException
+	 * @throws InterruptedException
+	 * @throws ExecutionException
+	 */
+	public void batch(int batchsize, int threads, final IBatchProcessor<T> batchProcessor)
+		throws CoreException, InterruptedException, ExecutionException {
+		if (sorting.isEmpty())
+			addSortingAsc(XPath.ID);
+
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+		final long itemcount = count();
+
+		int progress = 0;
+		List<Future<?>> futures = new ArrayList<Future<?>>(batchsize); // no need to synchronize
+
+		offset(0);
+		limit(batchsize);
+
+		List<IMendixObject> data = allMendixObjects();
+
+		while (data.size() > 0) {
+			for (final IMendixObject item : data) {
+				futures.add(pool.submit(new ParallelJobRunner<T>(this, batchProcessor, item, progress, itemcount)));
+				progress += 1;
+			}
+
+			while (!futures.isEmpty())
+				futures.remove(0).get(); // wait for all futures before proceeding to next iteration
+
+			offset(offset + data.size());
+			data = allMendixObjects();
+		}
+
+		if (pool.shutdownNow().size() > 0)
+			throw new IllegalStateException("Not all tasks where finished!");
+	}
+
+	public static Class<?> getProxyClassForEntityName(String entityname) {
+		{
+			String[] parts = entityname.split("\\.");
+			try {
+				return Class.forName(parts[0].toLowerCase() + ".proxies." + parts[1]);
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException("Cannot find class for entity: " + entityname + ": " + e.getMessage(), e);
+			}
+		}
+	}
+
+	public boolean deleteAll() throws CoreException {
+		limit(1000);
+		List<IMendixObject> objs = allMendixObjects();
+		while (!objs.isEmpty()) {
+			if (!Core.delete(context, objs.toArray(new IMendixObject[objs.size()])))
+				return false; // TODO: throw?
+
+			objs = allMendixObjects();
+		}
+		return true;
+	}
+
+	// Implement our own ESCAPE_XML because the original got deprecated and we
+	// originally translated only a very small
+	// subset of characters.
+	private static final CharSequenceTranslator ESCAPE_XML = new AggregateTranslator(
+		new LookupTranslator(EntityArrays.BASIC_ESCAPE),
+		new LookupTranslator(EntityArrays.APOS_ESCAPE));
 }

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -35,33 +35,61 @@ import com.mendix.systemwideinterfaces.core.IMendixObject;
 
 public class XPath<T> {
   /**
-   * Build in tokens, see:
-   * https://world.mendix.com/display/refguide3/XPath+Keywords+and+System+Variables
-   * 
+   * Built-in tokens, see:
+   * https://docs.mendix.com/refguide/xpath-keywords-and-system-variables/
    */
+
+  /* Keywords */
+  public static final String ID = "id";
+  public static final String NULL = "NULL";
+  public static final String Empty = "empty";
+
+  /* Object related */
   public static final String CurrentUser = "[%CurrentUser%]";
   public static final String CurrentObject = "[%CurrentObject%]";
 
+  /* Time related */
   public static final String CurrentDateTime = "[%CurrentDateTime%]";
-  public static final String BeginOfCurrentDay = "[%BeginOfCurrentDay%]";
-  public static final String EndOfCurrentDay = "[%EndOfCurrentDay%]";
-  public static final String BeginOfCurrentHour = "[%BeginOfCurrentHour%]";
-  public static final String EndOfCurrentHour = "[%EndOfCurrentHour%]";
   public static final String BeginOfCurrentMinute = "[%BeginOfCurrentMinute%]";
+  public static final String BeginOfCurrentMinuteUTC = "[%BeginOfCurrentMinuteUTC%]";
   public static final String EndOfCurrentMinute = "[%EndOfCurrentMinute%]";
-  public static final String BeginOfCurrentMonth = "[%BeginOfCurrentMonth%]";
-  public static final String EndOfCurrentMonth = "[%EndOfCurrentMonth%]";
+  public static final String EndOfCurrentMinuteUTC = "[%EndOfCurrentMinuteUTC%]";
+  public static final String BeginOfCurrentHour = "[%BeginOfCurrentHour%]";
+  public static final String BeginOfCurrentHourUTC = "[%BeginOfCurrentHourUTC%]";
+  public static final String EndOfCurrentHour = "[%EndOfCurrentHour%]";
+  public static final String EndOfCurrentHourUTC = "[%EndOfCurrentHourUTC%]";
+  public static final String BeginOfCurrentDay = "[%BeginOfCurrentDay%]";
+  public static final String BeginOfCurrentDayUTC = "[%BeginOfCurrentDayUTC%]";
+  public static final String EndOfCurrentDay = "[%EndOfCurrentDay%]";
+  public static final String EndOfCurrentDayUTC = "[%EndOfCurrentDayUTC%]";
+  public static final String BeginOfYesterday = "[%BeginOfYesterday%]";
+  public static final String BeginOfYesterdayUTC = "[%BeginOfYesterdayUTC%]";
+  public static final String EndOfYesterday = "[%EndOfYesterday%]";
+  public static final String EndOfYesterdayUTC = "[%EndOfYesterdayUTC%]";
+  public static final String BeginOfTomorrow = "[%BeginOfTomorrow%]";
+  public static final String BeginOfTomorrowUTC = "[%BeginOfTomorrowUTC%]";
+  public static final String EndOfTomorrow = "[%EndOfTomorrow%]";
+  public static final String EndOfTomorrowUTC = "[%EndOfTomorrowUTC%]";
   public static final String BeginOfCurrentWeek = "[%BeginOfCurrentWeek%]";
+  public static final String BeginOfCurrentWeekUTC = "[%BeginOfCurrentWeekUTC%]";
   public static final String EndOfCurrentWeek = "[%EndOfCurrentWeek%]";
+  public static final String EndOfCurrentWeekUTC = "[%EndOfCurrentWeekUTC%]";
+  public static final String BeginOfCurrentMonth = "[%BeginOfCurrentMonth%]";
+  public static final String BeginOfCurrentMonthUTC = "[%BeginOfCurrentMonthUTC%]";
+  public static final String EndOfCurrentMonth = "[%EndOfCurrentMonth%]";
+  public static final String EndOfCurrentMonthUTC = "[%EndOfCurrentMonthUTC%]";
+  public static final String BeginOfCurrentYear = "[%BeginOfCurrentYear%]";
+  public static final String BeginOfCurrentYearUTC = "[%BeginOfCurrentYearUTC%]";
+  public static final String EndOfCurrentYear = "[%EndOfCurrentYear%]";
+  public static final String EndOfCurrentYearUTC = "[%EndOfCurrentYearUTC%]";
 
   public static final String DayLength = "[%DayLength%]";
   public static final String HourLength = "[%HourLength%]";
   public static final String MinuteLength = "[%MinuteLength%]";
   public static final String SecondLength = "[%SecondLength%]";
   public static final String WeekLength = "[%WeekLength%]";
+  public static final String MonthLength = "[%MonthLength%]";
   public static final String YearLength = "[%YearLength%]";
-  public static final String ID = "id";
-  /** End builtin tokens */
 
   private String entity;
   private int offset = 0;
@@ -588,7 +616,7 @@ public class XPath<T> {
 
   public static String valueToXPathValue(Object value) {
     if (value == null)
-      return "NULL";
+      return NULL;
 
     // Complex objects
     if (value instanceof IMendixIdentifier)

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -142,9 +142,7 @@ public class XPath<T> {
   }
 
   public XPath<T> eq(Object... pathAndValue) {
-    assertEven(pathAndValue);
-    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "=",
-        pathAndValue[pathAndValue.length - 1]);
+    return compare("=", pathAndValue);
   }
 
   public XPath<T> equalsIgnoreCase(Object attr, String value) {
@@ -161,9 +159,39 @@ public class XPath<T> {
   }
 
   public XPath<T> notEq(Object... pathAndValue) {
-    assertEven(pathAndValue);
-    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "!=",
-        pathAndValue[pathAndValue.length - 1]);
+    return compare("!=", pathAndValue);
+  }
+
+  public XPath<T> gt(Object attr, Object valuecomparison) {
+    return compare(attr, ">", valuecomparison);
+  }
+
+  public XPath<T> gt(Object... pathAndValue) {
+    return compare(">", pathAndValue);
+  }
+
+  public XPath<T> gte(Object attr, Object valuecomparison) {
+    return compare(attr, ">=", valuecomparison);
+  }
+
+  public XPath<T> gte(Object... pathAndValue) {
+    return compare(">=", pathAndValue);
+  }
+
+  public XPath<T> lt(Object attr, Object valuecomparison) {
+    return compare(attr, "<", valuecomparison);
+  }
+
+  public XPath<T> lt(Object... pathAndValue) {
+    return compare("<", pathAndValue);
+  }
+
+  public XPath<T> lte(Object attr, Object valuecomparison) {
+    return compare(attr, "<=", valuecomparison);
+  }
+
+  public XPath<T> lte(Object... pathAndValue) {
+    return compare("<=", pathAndValue);
   }
 
   public XPath<T> contains(Object attr, String value) {
@@ -186,6 +214,12 @@ public class XPath<T> {
 
   public XPath<T> compare(Object attr, String operator, Object value) {
     return compare(new Object[] { attr }, operator, value);
+  }
+
+  public XPath<T> compare(String operator, Object[] pathAndValue) {
+    assertEven(pathAndValue);
+    int lastIndex = pathAndValue.length - 1;
+    return compare(Arrays.copyOf(pathAndValue, lastIndex), operator, pathAndValue[lastIndex]);
   }
 
   public XPath<T> compare(Object[] path, String operator, Object value) {
@@ -268,46 +302,6 @@ public class XPath<T> {
     if (builder.length() > 0)
       return "//" + this.entity + "[" + builder.toString() + "]";
     return "//" + this.entity;
-  }
-
-  public XPath<T> gt(Object attr, Object valuecomparison) {
-    return compare(attr, ">", valuecomparison);
-  }
-
-  public XPath<T> gt(Object... pathAndValue) {
-    assertEven(pathAndValue);
-    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), ">",
-        pathAndValue[pathAndValue.length - 1]);
-  }
-
-  public XPath<T> gte(Object attr, Object valuecomparison) {
-    return compare(attr, ">=", valuecomparison);
-  }
-
-  public XPath<T> gte(Object... pathAndValue) {
-    assertEven(pathAndValue);
-    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), ">=",
-        pathAndValue[pathAndValue.length - 1]);
-  }
-
-  public XPath<T> lt(Object attr, Object valuecomparison) {
-    return compare(attr, "<", valuecomparison);
-  }
-
-  public XPath<T> lt(Object... pathAndValue) {
-    assertEven(pathAndValue);
-    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "<",
-        pathAndValue[pathAndValue.length - 1]);
-  }
-
-  public XPath<T> lte(Object attr, Object valuecomparison) {
-    return compare(attr, "<=", valuecomparison);
-  }
-
-  public XPath<T> lte(Object... pathAndValue) {
-    assertEven(pathAndValue);
-    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "<=",
-        pathAndValue[pathAndValue.length - 1]);
   }
 
   private void assertEmptyStack() throws IllegalStateException {

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -39,7 +39,6 @@ public class XPath<T> {
    * https://world.mendix.com/display/refguide3/XPath+Keywords+and+System+Variables
    * 
    */
-
   public static final String CurrentUser = "[%CurrentUser%]";
   public static final String CurrentObject = "[%CurrentObject%]";
 
@@ -62,25 +61,24 @@ public class XPath<T> {
   public static final String WeekLength = "[%WeekLength%]";
   public static final String YearLength = "[%YearLength%]";
   public static final String ID = "id";
-
   /** End builtin tokens */
 
   private String entity;
   private int offset = 0;
   private int limit = -1;
-  private LinkedHashMap<String, String> sorting = new LinkedHashMap<String, String>(); // important, linked map!
+  // important, linked map, insertion order is relevant!
+  private LinkedHashMap<String, String> sorting = new LinkedHashMap<String, String>();
   private LinkedList<String> closeStack = new LinkedList<String>();
   private StringBuilder builder = new StringBuilder();
   private IContext context;
   private Class<T> proxyClass;
-  private boolean requiresBinOp = false; // state property, indicates whether and 'and' needs to be inserted before the
-                                         // next constraint
+  // state property, indicates whether 'and' needs to be inserted before the next
+  // constraint
+  private boolean requiresBinOp = false;
 
   public static XPath<IMendixObject> create(IContext c, String entityType) {
     XPath<IMendixObject> res = new XPath<IMendixObject>(c, IMendixObject.class);
-
     res.entity = entityType;
-
     return res;
   }
 
@@ -174,6 +172,18 @@ public class XPath<T> {
     return this.requireBinOp(true);
   }
 
+  public XPath<T> startsWith(Object attr, String value) {
+    autoInsertAnd().append(" starts-with(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value))
+        .append(") ");
+    return this.requireBinOp(true);
+  }
+
+  public XPath<T> endsWith(Object attr, String value) {
+    autoInsertAnd().append(" ends-with(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value))
+        .append(") ");
+    return this.requireBinOp(true);
+  }
+
   public XPath<T> compare(Object attr, String operator, Object value) {
     return compare(new Object[] { attr }, operator, value);
   }
@@ -255,19 +265,48 @@ public class XPath<T> {
   }
 
   public String getXPath() {
-
     if (builder.length() > 0)
       return "//" + this.entity + "[" + builder.toString() + "]";
     return "//" + this.entity;
   }
 
   public XPath<T> gt(Object attr, Object valuecomparison) {
-    return compare(attr, ">=", valuecomparison);
+    return compare(attr, ">", valuecomparison);
   }
 
   public XPath<T> gt(Object... pathAndValue) {
     assertEven(pathAndValue);
+    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), ">",
+        pathAndValue[pathAndValue.length - 1]);
+  }
+
+  public XPath<T> gte(Object attr, Object valuecomparison) {
+    return compare(attr, ">=", valuecomparison);
+  }
+
+  public XPath<T> gte(Object... pathAndValue) {
+    assertEven(pathAndValue);
     return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), ">=",
+        pathAndValue[pathAndValue.length - 1]);
+  }
+
+  public XPath<T> lt(Object attr, Object valuecomparison) {
+    return compare(attr, "<", valuecomparison);
+  }
+
+  public XPath<T> lt(Object... pathAndValue) {
+    assertEven(pathAndValue);
+    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "<",
+        pathAndValue[pathAndValue.length - 1]);
+  }
+
+  public XPath<T> lte(Object attr, Object valuecomparison) {
+    return compare(attr, "<=", valuecomparison);
+  }
+
+  public XPath<T> lte(Object... pathAndValue) {
+    assertEven(pathAndValue);
+    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "<=",
         pathAndValue[pathAndValue.length - 1]);
   }
 

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -33,806 +33,796 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.systemwideinterfaces.core.IMendixIdentifier;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 
-public class XPath<T>
-{
-	/** Build in tokens, see: https://world.mendix.com/display/refguide3/XPath+Keywords+and+System+Variables
-	 * 
-	 */
-	
-	public static final String CurrentUser =  "[%CurrentUser%]";
-	public static final String CurrentObject =  "[%CurrentObject%]";
+public class XPath<T> {
+  /**
+   * Build in tokens, see:
+   * https://world.mendix.com/display/refguide3/XPath+Keywords+and+System+Variables
+   * 
+   */
 
-	public static final String CurrentDateTime =  "[%CurrentDateTime%]";
-	public static final String BeginOfCurrentDay =  "[%BeginOfCurrentDay%]";
-	public static final String EndOfCurrentDay =  "[%EndOfCurrentDay%]";
-	public static final String BeginOfCurrentHour =  "[%BeginOfCurrentHour%]";
-	public static final String EndOfCurrentHour =  "[%EndOfCurrentHour%]";
-	public static final String BeginOfCurrentMinute =  "[%BeginOfCurrentMinute%]";
-	public static final String EndOfCurrentMinute =  "[%EndOfCurrentMinute%]";
-	public static final String BeginOfCurrentMonth =  "[%BeginOfCurrentMonth%]";
-	public static final String EndOfCurrentMonth =  "[%EndOfCurrentMonth%]";
-	public static final String BeginOfCurrentWeek =  "[%BeginOfCurrentWeek%]";
-	public static final String EndOfCurrentWeek =  "[%EndOfCurrentWeek%]";
+  public static final String CurrentUser = "[%CurrentUser%]";
+  public static final String CurrentObject = "[%CurrentObject%]";
 
-	public static final String DayLength =  "[%DayLength%]";
-	public static final String HourLength =  "[%HourLength%]";
-	public static final String MinuteLength =  "[%MinuteLength%]";
-	public static final String SecondLength =  "[%SecondLength%]";
-	public static final String WeekLength =  "[%WeekLength%]";
-	public static final String YearLength =  "[%YearLength%]";
-	public static final String ID	= "id";
-	
-	/** End builtin tokens */
-	
-	private String	entity;
-	private int	offset = 0;
-	private int	limit = -1;
-	private LinkedHashMap<String, String> sorting = new LinkedHashMap<String, String>(); //important, linked map!
-	private LinkedList<String> closeStack = new LinkedList<String>();
-	private StringBuilder builder = new StringBuilder();
-	private IContext	context;
-	private Class<T>	proxyClass;
-	private boolean requiresBinOp = false; //state property, indicates whether and 'and' needs to be inserted before the next constraint
-	
-	public static XPath<IMendixObject> create(IContext c, String entityType) {
-		XPath<IMendixObject> res = new XPath<IMendixObject>(c, IMendixObject.class);
-		
-		res.entity = entityType;
-		
-		return res;
-	}
-	
-	public static <U> XPath<U> create(IContext c, Class<U> proxyClass) {
-		return new XPath<U>(c, proxyClass);
-	}
-	
-	private XPath(IContext c, Class<T> proxyClass) {
-		try
-		{
-			if (proxyClass != IMendixObject.class)
-				this.entity = (String) proxyClass.getMethod("getType").invoke(null);
-		}
-		catch (Exception e)
-		{
-			throw new IllegalArgumentException("Failed to determine entity type of proxy class. Did you provide a valid proxy class? '" + proxyClass.getName() + "'");
-		}
+  public static final String CurrentDateTime = "[%CurrentDateTime%]";
+  public static final String BeginOfCurrentDay = "[%BeginOfCurrentDay%]";
+  public static final String EndOfCurrentDay = "[%EndOfCurrentDay%]";
+  public static final String BeginOfCurrentHour = "[%BeginOfCurrentHour%]";
+  public static final String EndOfCurrentHour = "[%EndOfCurrentHour%]";
+  public static final String BeginOfCurrentMinute = "[%BeginOfCurrentMinute%]";
+  public static final String EndOfCurrentMinute = "[%EndOfCurrentMinute%]";
+  public static final String BeginOfCurrentMonth = "[%BeginOfCurrentMonth%]";
+  public static final String EndOfCurrentMonth = "[%EndOfCurrentMonth%]";
+  public static final String BeginOfCurrentWeek = "[%BeginOfCurrentWeek%]";
+  public static final String EndOfCurrentWeek = "[%EndOfCurrentWeek%]";
 
-		this.proxyClass = proxyClass;
-		this.context = c;
-	}
-	
-	private XPath<T> autoInsertAnd() {
-		if (requiresBinOp)
-			and();
-		return this;
-	}
-	
-	private XPath<T> requireBinOp(boolean requires) {
-		requiresBinOp = requires;
-		return this;
-	}
-	
-	public XPath<T> offset(int offset2) {
-		if (offset2 < 0)
-			throw new IllegalArgumentException("Offset should not be negative");
-		this.offset  = offset2;
-		return this;
-	}
-	
-	public XPath<T> limit(int limit2) {
-		if (limit2 < -1 || limit2 == 0)
-			throw new IllegalArgumentException("Limit should be larger than zero or -1. ");
+  public static final String DayLength = "[%DayLength%]";
+  public static final String HourLength = "[%HourLength%]";
+  public static final String MinuteLength = "[%MinuteLength%]";
+  public static final String SecondLength = "[%SecondLength%]";
+  public static final String WeekLength = "[%WeekLength%]";
+  public static final String YearLength = "[%YearLength%]";
+  public static final String ID = "id";
 
-		this.limit = limit2;
-		return this;
-	}
-	
-	public XPath<T> addSortingAsc(Object... sortparts) {
-		assertOdd(sortparts);
-		sorting.put(StringUtils.join(sortparts, '/'), "asc");
-		return this;
-	}
-	
-	public XPath<T> addSortingDesc(Object... sortparts) {
-		sorting.put(StringUtils.join(sortparts, "/"), "desc");
-		return this;
-	}	
-	
-	public XPath<T> eq(Object attr, Object valuecomparison) {
-		return compare(attr, "=", valuecomparison);
-	}
-	
-	public XPath<T> eq(Object... pathAndValue) {
-		assertEven(pathAndValue);
-		return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length -1), "=", pathAndValue[pathAndValue.length -1 ]);
-	}
-	
-	public XPath<T> equalsIgnoreCase(Object attr, String value) {
-		//(contains(Name, $email) and length(Name) = length($email)
-		return 
-			subconstraint()
-			.contains(attr, value)
-			.and()
-			.append(" length(" + attr + ") = ").append(value == null ? "0" : valueToXPathValue(value.length()))	
-			.close();
-	}
-	
-	public XPath<T> notEq(Object attr, Object valuecomparison) {
-		return compare(attr, "!=", valuecomparison);
-	}
-	
-	public XPath<T> notEq(Object... pathAndValue) {
-		assertEven(pathAndValue);
-		return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length -1), "!=", pathAndValue[pathAndValue.length -1 ]);
-	}
+  /** End builtin tokens */
 
-	public XPath<T> contains(Object attr, String value)
-	{
-		autoInsertAnd().append(" contains(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value)).append(") ");
-		return this.requireBinOp(true);
-	}
-	
-	public XPath<T> compare(Object attr, String operator, Object value) {
-		return compare(new Object[] {attr}, operator, value);
-	}
-	
-	public XPath<T> compare(Object[] path, String operator, Object value) {
-		assertOdd(path);
-		autoInsertAnd().append(StringUtils.join(path, '/')).append(" ").append(operator).append(" ").append(valueToXPathValue(value));
-		return this.requireBinOp(true);
-	}
-	
-	public XPath<T> hasReference(Object... path)
-	{
-		assertEven(path); //Reference + entity type
-		autoInsertAnd().append(StringUtils.join(path, '/'));
-		return this.requireBinOp(true);
-	}
+  private String entity;
+  private int offset = 0;
+  private int limit = -1;
+  private LinkedHashMap<String, String> sorting = new LinkedHashMap<String, String>(); // important, linked map!
+  private LinkedList<String> closeStack = new LinkedList<String>();
+  private StringBuilder builder = new StringBuilder();
+  private IContext context;
+  private Class<T> proxyClass;
+  private boolean requiresBinOp = false; // state property, indicates whether and 'and' needs to be inserted before the
+                                         // next constraint
 
-	public XPath<T> subconstraint(Object... path) {
-		assertEven(path);
-		autoInsertAnd().append(StringUtils.join(path, '/')).append("[");
-		closeStack.push("]");
-		return this.requireBinOp(false);
-	}	
-	
-	public XPath<T> subconstraint() {
-		autoInsertAnd().append("(");
-		closeStack.push(")");
-		return this.requireBinOp(false);
-	}
-	
-	public XPath<T> addConstraint()
-	{
-		if (!closeStack.isEmpty() && !closeStack.peek().equals("]"))
-			throw new IllegalStateException("Cannot add a constraint while in the middle of something else..");
-		
-		return append("][").requireBinOp(false);
-	}
-	
-	public XPath<T> close() {
-		if (closeStack.isEmpty())
-			throw new IllegalStateException("XPathbuilder close stack is empty!");
-		append(closeStack.pop());
-		return requireBinOp(true);
-		//MWE: note that a close does not necessary require a binary operator, for example with two subsequent block([bla][boe]) constraints, 
-		//but openening a binary constraint reset the flag, so that should be no issue
-	}
-	
-	public XPath<T> or() {
-		if (!requiresBinOp)
-			throw new IllegalStateException("Received 'or' but no binary operator was expected");
-		return append(" or ").requireBinOp(false);
-	}
-	
-	public XPath<T> and() {
-		if (!requiresBinOp)
-			throw new IllegalStateException("Received 'and' but no binary operator was expected");
-		return append(" and ").requireBinOp(false);
-	}
-	
-	public XPath<T> not() {
-		autoInsertAnd();
-		closeStack.push(")");
-		return append(" not(").requireBinOp(false);
-	}
-	
-	private void assertOdd(Object[] stuff) {
-		if (stuff == null || stuff.length == 0 || stuff.length % 2 == 0)
-			throw new IllegalArgumentException("Expected an odd number of xpath path parts");
-	}
-	
-	private void assertEven(Object[] stuff) {
-		if (stuff == null || stuff.length == 0 || stuff.length % 2 == 1)
-			throw new IllegalArgumentException("Expected an even number of xpath path parts");
-	}
-	
-	public XPath<T> append(String s) {
-		builder.append(s);
-		return this;
-	}
-	
-	public String getXPath() {
-	
-		if (builder.length() > 0)
-			return "//" + this.entity + "[" + builder.toString() + "]";
-		return "//" + this.entity;
-	}
+  public static XPath<IMendixObject> create(IContext c, String entityType) {
+    XPath<IMendixObject> res = new XPath<IMendixObject>(c, IMendixObject.class);
 
-	public XPath<T> gt(Object attr, Object valuecomparison) {
-		return compare(attr,">=", valuecomparison);
-	}
+    res.entity = entityType;
 
-	public XPath<T> gt(Object... pathAndValue) {
-		assertEven(pathAndValue);
-		return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length -1), ">=", pathAndValue[pathAndValue.length -1 ]);
-	}
-	
-	private void assertEmptyStack() throws IllegalStateException
-	{
-		if (!closeStack.isEmpty())
-			throw new IllegalStateException("Invalid xpath expression, not all items where closed");
-	}
-	
-	public long count( ) throws CoreException {
-		assertEmptyStack();
+    return res;
+  }
 
-		return Core.retrieveXPathQueryAggregate(context, "count(" + getXPath() +")");
-	}
+  public static <U> XPath<U> create(IContext c, Class<U> proxyClass) {
+    return new XPath<U>(c, proxyClass);
+  }
 
-	
-	public IMendixObject firstMendixObject() throws CoreException {
-		assertEmptyStack();
-		
-		List<IMendixObject> result = Core.retrieveXPathQuery(context, getXPath(), 1, offset, sorting);
-		if (result.isEmpty())
-			return null;
-		return result.get(0);
-	}
-	
-	public T first() throws CoreException {
-		return createProxy(context, proxyClass, firstMendixObject());
-	}
-	
+  private XPath(IContext c, Class<T> proxyClass) {
+    try {
+      if (proxyClass != IMendixObject.class)
+        this.entity = (String) proxyClass.getMethod("getType").invoke(null);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Failed to determine entity type of proxy class. Did you provide a valid proxy class? '"
+              + proxyClass.getName() + "'");
+    }
 
-	/**
-	 * Given a set of attribute names and values, tries to find the first object that matches all conditions, or creates one
-	 * 
-	 * @param keysAndValues
-	 * @return
-	 * @throws CoreException 
-	 */
-	public T findOrCreateNoCommit(Object... keysAndValues) throws CoreException
-	{
-		T res = findFirst(keysAndValues);
-		
-		return res != null ? res : constructInstance(false, keysAndValues);
-	}
+    this.proxyClass = proxyClass;
+    this.context = c;
+  }
 
-	
-	public T findOrCreate(Object... keysAndValues) throws CoreException {
-		T res = findFirst(keysAndValues);
+  private XPath<T> autoInsertAnd() {
+    if (requiresBinOp)
+      and();
+    return this;
+  }
 
-		return res != null ? res : constructInstance(true, keysAndValues);
+  private XPath<T> requireBinOp(boolean requires) {
+    requiresBinOp = requires;
+    return this;
+  }
 
-	}
-	
-	public T findOrCreateSynchronized(Object... keysAndValues) throws CoreException, InterruptedException {
-		T res = findFirst(keysAndValues);
-		
-		if (res != null) {
-			return res;
-		} else {
-			synchronized (Core.getMetaObject(entity)) {
-				IContext synchronizedContext = context.getSession().createContext().createSudoClone();
-				try {
-					synchronizedContext.startTransaction();
-					res = createProxy(synchronizedContext, proxyClass, XPath.create(synchronizedContext, entity).findOrCreate(keysAndValues));
-					synchronizedContext.endTransaction();
-					return res;
-				} catch (CoreException e) {
-					if (synchronizedContext.isInTransaction()) {
-						synchronizedContext.rollbackTransaction();
-					}
-					throw e;
-				}
-			}
-		}
-	}	
-	
-	public T findFirst(Object... keysAndValues)
-			throws IllegalStateException, CoreException
-	{
-		if (builder.length() > 0)
-			throw new IllegalStateException("FindFirst can only be used on XPath which do not have constraints already");
-		
-		assertEven(keysAndValues);
-		for(int i = 0; i < keysAndValues.length; i+= 2)
-			eq(keysAndValues[i], keysAndValues[i + 1]);
-		
-		T res = this.first();
-		return res;
-	}
-	
+  public XPath<T> offset(int offset2) {
+    if (offset2 < 0)
+      throw new IllegalArgumentException("Offset should not be negative");
+    this.offset = offset2;
+    return this;
+  }
 
-	/**
-	 * Creates one instance of the type of this XPath query, and initializes the provided attributes to the provided values. 
-	 * @param keysAndValues AttributeName, AttributeValue, AttributeName2, AttributeValue2... list. 
-	 * @return
-	 * @throws CoreException
-	 */
-	public T constructInstance(boolean autoCommit, Object... keysAndValues) throws CoreException
-	{
-		assertEven(keysAndValues);
-		IMendixObject newObj = Core.instantiate(context, this.entity);
-		
-		for(int i = 0; i < keysAndValues.length; i+= 2)
-			newObj.setValue(context, String.valueOf(keysAndValues[i]), toMemberValue(keysAndValues[i + 1]));
-		
-		if (autoCommit)
-			Core.commit(context, newObj);
-		
-		return createProxy(context, proxyClass, newObj);
-	}
-	
-	/**
-	 * Given a current collection of primitive values, checks if for each value in the collection an object in the database exists. 
-	 * It creates a new object if needed, and removes any superfluos objects in the database that are no longer in the collection.  
-	 * 
-	 * @param currentCollection The collection that act as reference for the objects that should be in this database in the end. 
-	 * @param comparisonAttribute The attribute that should store the value as decribed in the collection
-	 * @param autoDelete Automatically remove any superfluous objects form the database
-	 * @param keysAndValues Constraints that should hold for the set of objects that are deleted or created. Objects outside this constraint are not processed.
-	 * 
-	 * @return A pair of lists. The first list contains the newly created objects, the second list contains the objects that (should be or are) removed. 
-	 * @throws CoreException
-	 */
-	public <U> ImmutablePair<List<T>, List<T>> syncDatabaseWithCollection(Collection<U> currentCollection, Object comparisonAttribute, boolean autoDelete, Object... keysAndValues) throws CoreException {
-		if (builder.length() > 0)
-			throw new IllegalStateException("syncDatabaseWithCollection can only be used on XPath which do not have constraints already");
+  public XPath<T> limit(int limit2) {
+    if (limit2 < -1 || limit2 == 0)
+      throw new IllegalArgumentException("Limit should be larger than zero or -1. ");
 
-		
-		List<T> added = new ArrayList<T>();
-		List<T> removed = new ArrayList<T>();
-		
-		Set<U> col = new HashSet<U>(currentCollection);
-		
-		for(int i = 0; i < keysAndValues.length; i+= 2)
-			eq(keysAndValues[i], keysAndValues[i + 1]);
-		
-		for(IMendixObject existingItem : this.allMendixObjects()) {
-			//Item is still available 
-			if (col.remove(existingItem.getValue(context, String.valueOf(comparisonAttribute)))) 
-				continue;
-				
-			//No longer available
-			removed.add(createProxy(context, this.proxyClass, existingItem));
-			if (autoDelete) 
-				Core.delete(context, existingItem);
-		}
-		
-		//Some items where not found in the database
-		for(U value : col) {
-			
-			//In apache lang3, this would just be: ArrayUtils.addAll(keysAndValues, comparisonAttribute, value)
-			Object[] args = new Object[keysAndValues.length + 2];
-			for(int i = 0; i < keysAndValues.length; i++)
-				args[i] = keysAndValues[i];
-			args[keysAndValues.length] = comparisonAttribute;
-			args[keysAndValues.length + 1] = value;
-			
-			T newItem = constructInstance(true, args);
-			added.add(newItem);
-		}
-		
-		//Oké, stupid, Pair is also only available in apache lang3, so lets use a simple pair implementation for now
-		return ImmutablePair.of(added, removed);
-	}
-	
-	public T firstOrWait(long timeoutMSecs) throws CoreException, InterruptedException
-	{
-		IMendixObject result = null;
-		
-		long start = System.currentTimeMillis();
-		int  sleepamount = 200;
-		int  loopcount = 0;
-		
-		while (result == null) {
-			loopcount += 1;
-			result = firstMendixObject();
-			
-			long now = System.currentTimeMillis();
-			
-			if (start + timeoutMSecs < now) //Time expired
-				break;
+    this.limit = limit2;
+    return this;
+  }
 
-			if (loopcount % 5 == 0)
-				sleepamount *= 1.5;
-			
-			//not expired, wait a bit
-			if (result == null)
-				Thread.sleep(sleepamount);
-		}
-		
-		return createProxy(context, proxyClass, result); 
-	}
-	
-	
-	public List<IMendixObject> allMendixObjects() throws CoreException {
-		assertEmptyStack();
+  public XPath<T> addSortingAsc(Object... sortparts) {
+    assertOdd(sortparts);
+    sorting.put(StringUtils.join(sortparts, '/'), "asc");
+    return this;
+  }
 
-		return Core.retrieveXPathQuery(context, getXPath(), limit, offset, sorting);
-	}
-	
-	public List<T> all() throws CoreException {
-		List<T> res = new ArrayList<T>();
-		for(IMendixObject o : allMendixObjects())
-			res.add(createProxy(context, proxyClass, o));
-		
-		return res;
-	}
-	
-	@Override
-	public String toString() {
-		return getXPath();
-	}
+  public XPath<T> addSortingDesc(Object... sortparts) {
+    sorting.put(StringUtils.join(sortparts, "/"), "desc");
+    return this;
+  }
 
+  public XPath<T> eq(Object attr, Object valuecomparison) {
+    return compare(attr, "=", valuecomparison);
+  }
 
-	/** 
-	 * 
-	 * 
-	 * Static utility functions 
-	 * 
-	 * 
-	*/
-	
-	//cache for proxy constructors. Reflection is slow, so reuse as much as possible
-	private static Map<String, Method> initializers = new HashMap<String, Method>();
-	
-	public static <T> List<T> createProxyList(IContext c, Class<T> proxieClass, List<IMendixObject> objects) {
-		List<T> res = new ArrayList<T>();
-		if (objects == null || objects.size() == 0)
-			return res;
-		
-		for(IMendixObject o : objects)
-			res.add(createProxy(c, proxieClass, o));
-		
-		return res;
-	}
-	
-	public static <T> T createProxy(IContext c, Class<T> proxieClass, IMendixObject object) {
-		//Borrowed from nl.mweststrate.pages.MxQ package
-		
-		if (object == null)
-			return null;
-		
-		if (c == null || proxieClass == null)
-			throw new IllegalArgumentException("[CreateProxy] No context or proxieClass provided. ");
-		
-		//jeuj, we expect IMendixObject's. Thats nice..
-		if (proxieClass == IMendixObject.class)
-			return proxieClass.cast(object); //.. since we can do a direct cast
-		
-		try {
-			String entityType = object.getType();
-			
-			if (!initializers.containsKey(entityType)) { 
-			
-				String[] entType = object.getType().split("\\.");
-				Class<?> realClass = Class.forName(entType[0].toLowerCase()+".proxies."+entType[1]);
+  public XPath<T> eq(Object... pathAndValue) {
+    assertEven(pathAndValue);
+    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "=",
+        pathAndValue[pathAndValue.length - 1]);
+  }
 
-				initializers.put(entityType, realClass.getMethod("initialize", IContext.class, IMendixObject.class));
-			}
-			
-			//find constructor
-			Method m = initializers.get(entityType);
-			
-			//create proxy object
-			Object result = m.invoke(null, c, object);
-			
-			//cast, but check first is needed because the actual type might be a subclass of the requested type
-			if (!proxieClass.isAssignableFrom(result.getClass()))
-				throw new IllegalArgumentException("The type of the object ('" + object.getType() + "') is not (a subclass) of '" + proxieClass.getName()+"'");
-			
-			T proxie = proxieClass.cast(result);
-			return proxie;
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Unable to instantiate proxie: " + e.getMessage(), e);
-		}
-	}
-	
-	public static String valueToXPathValue(Object value)
-	{
-		if (value == null)
-			return "NULL"; 
+  public XPath<T> equalsIgnoreCase(Object attr, String value) {
+    // (contains(Name, $email) and length(Name) = length($email)
+    return subconstraint()
+        .contains(attr, value)
+        .and()
+        .append(" length(" + attr + ") = ").append(value == null ? "0" : valueToXPathValue(value.length()))
+        .close();
+  }
 
-		//Complex objects
-		if (value instanceof IMendixIdentifier)
-			return "'" + String.valueOf(((IMendixIdentifier) value).toLong()) +  "'";
-		if (value instanceof IMendixObject)
-			return valueToXPathValue(((IMendixObject)value).getId());
-		if (value instanceof List<?>)
-			throw new IllegalArgumentException("List based values are not supported!");
-		
-		//Primitives
-		if (value instanceof Date)
-			return String.valueOf(((Date) value).getTime());
-		if (value instanceof Long || value instanceof Integer)
-			return String.valueOf(value);
-		if (value instanceof Double || value instanceof Float) {
-			//make sure xpath understands our number formatting
-			NumberFormat format = NumberFormat.getNumberInstance(Locale.ENGLISH);
-			format.setMaximumFractionDigits(10);
-			format.setGroupingUsed(false);
-			return format.format(value);
-		}
-		if (value instanceof Boolean) {
-			return value.toString() + "()"; //xpath boolean, you know..
-		}
-		if (value instanceof String) {
-			return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
-		}
-		
-		//Object, assume its a proxy and deproxiefy
-		try
-		{
-			IMendixObject mo = proxyToMendixObject(value);
-			return valueToXPathValue(mo);
-		}
-		catch (NoSuchMethodException e)
-		{
-			//This is O.K. just not a proxy object...
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to retrieve MendixObject from proxy: " + e.getMessage(), e);
-		}
-		
-		//assume some string representation
-		return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
-	}
-	
-	public static IMendixObject proxyToMendixObject(Object value)
-		throws NoSuchMethodException, SecurityException, IllegalAccessException,
-		IllegalArgumentException, InvocationTargetException
-	{
-		Method m = value.getClass().getMethod("getMendixObject");
-		IMendixObject mo = (IMendixObject) m.invoke(value);
-		return mo;
-	}
+  public XPath<T> notEq(Object attr, Object valuecomparison) {
+    return compare(attr, "!=", valuecomparison);
+  }
 
-	public static <T> List<IMendixObject> proxyListToMendixObjectList(
-			List<T> objects) throws SecurityException, IllegalArgumentException, NoSuchMethodException, IllegalAccessException, InvocationTargetException
-	{
-		ArrayList<IMendixObject> res = new ArrayList<IMendixObject>(objects.size());
-		for(T i : objects)
-			res.add(proxyToMendixObject(i));
-		return res;
-	}
-	
-	public static Object toMemberValue(Object value)
-	{
-		if (value == null)
-			return null; 
+  public XPath<T> notEq(Object... pathAndValue) {
+    assertEven(pathAndValue);
+    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), "!=",
+        pathAndValue[pathAndValue.length - 1]);
+  }
 
-		//Complex objects
-		if (value instanceof IMendixIdentifier)
-			return value;
-		if (value instanceof IMendixObject)
-			return ((IMendixObject)value).getId();
-		
-		if (value instanceof List<?>)
-			throw new IllegalArgumentException("List based values are not supported!");
-		
-		//Primitives
-		if (   value instanceof Date 
-				|| value instanceof Long 
-				|| value instanceof Integer
-			  || value instanceof Double 
-			  || value instanceof Float
-			  || value instanceof Boolean
-			  || value instanceof String) {
-			return value;
-		}
-		
-		if (value.getClass().isEnum())
-			return value.toString();
+  public XPath<T> contains(Object attr, String value) {
+    autoInsertAnd().append(" contains(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value))
+        .append(") ");
+    return this.requireBinOp(true);
+  }
 
-		//Object, assume its a proxy and deproxiefy
-		try
-		{
-			Method m = value.getClass().getMethod("getMendixObject");
-			IMendixObject mo = (IMendixObject) m.invoke(value);
-			return toMemberValue(mo);
-		}
-		catch (NoSuchMethodException e)
-		{
-			//This is O.K. just not a proxy object...
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to convert object to IMendixMember compatible value '" + value + "': " + e.getMessage(), e);
-		}
-		
-		throw new RuntimeException("Failed to convert object to IMendixMember compatible value: " + value);
-	}
-	
-	public static interface IBatchProcessor<T> {
-		public void onItem(T item, long offset, long total) throws Exception;
-	}
-	
-	private static final class ParallelJobRunner<T> implements Callable<Boolean>
-	{
-		private final XPath<T> self;
-		private final IBatchProcessor<T> batchProcessor;
-		private final IMendixObject item;
-		private long index;
-		private long count;
+  public XPath<T> compare(Object attr, String operator, Object value) {
+    return compare(new Object[] { attr }, operator, value);
+  }
 
-		ParallelJobRunner(XPath<T> self, IBatchProcessor<T> batchProcessor, IMendixObject item, long index, long count)
-		{
-			this.self = self;
-			this.batchProcessor = batchProcessor;
-			this.item = item;
-			this.index = index;
-			this.count = count;
-		}
+  public XPath<T> compare(Object[] path, String operator, Object value) {
+    assertOdd(path);
+    autoInsertAnd().append(StringUtils.join(path, '/')).append(" ").append(operator).append(" ")
+        .append(valueToXPathValue(value));
+    return this.requireBinOp(true);
+  }
 
-		@Override
-		public Boolean call()
-		{
-			try
-			{
-				batchProcessor.onItem(XPath.createProxy(Core.createSystemContext(), self.proxyClass, item), index, count); //mwe: hmm, many contexts..
-				return true;
-			}
-			catch (Exception e)
-			{
-				throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", self.toString(), self.offset, e.getMessage()), e);
-			}
-		}
-	}
-	
+  public XPath<T> hasReference(Object... path) {
+    assertEven(path); // Reference + entity type
+    autoInsertAnd().append(StringUtils.join(path, '/'));
+    return this.requireBinOp(true);
+  }
 
-	/**
-	 * Retreives all items in this xpath query in batches of a limited size. 
-	 * Not that this function does not start a new transaction for all the batches,
-	 * rather, it just limits the number of objects being retrieved and kept in memory at the same time. 
-	 * 
-	 * So it only batches the retrieve process, not the optional manipulations done in the onItem method.  
-	 * @param batchsize
-	 * @param batchProcessor
-	 * @throws CoreException
-	 */
-	public void batch(int batchsize, IBatchProcessor<T> batchProcessor) throws CoreException
-	{
-		if (this.sorting.isEmpty())
-			this.addSortingAsc(XPath.ID);
-		
-		long count = this.count();
-		
-		int baseoffset = this.offset;
-		int baselimit = this.limit;
-		
-		boolean useBaseLimit = baselimit > -1;
-		
-		this.offset(baseoffset);
-		List<T> data;
-		
-		long i = 0;
+  public XPath<T> subconstraint(Object... path) {
+    assertEven(path);
+    autoInsertAnd().append(StringUtils.join(path, '/')).append("[");
+    closeStack.push("]");
+    return this.requireBinOp(false);
+  }
 
-		do {
-			int newlimit = useBaseLimit ? Math.min(batchsize, baseoffset + baselimit - this.offset) : batchsize;
-			if (newlimit == 0)
-				break; //where done, no more data is needed
-			
-			this.limit(newlimit);
-			data = this.all();
+  public XPath<T> subconstraint() {
+    autoInsertAnd().append("(");
+    closeStack.push(")");
+    return this.requireBinOp(false);
+  }
 
-			for(T item : data) {
-				i += 1;
-				try
-				{
-					batchProcessor.onItem(item, i, Math.max(i, count));
-				}
-				catch (Exception e)
-				{
-					throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", this.toString(), this.offset, e.getMessage()), e);
-				}
-			}
-			
-			this.offset(this.offset + data.size());
-		} while(data.size() > 0);
-	}
-	
-	/**
-	 * Batch with parallelization.
-	 * 
-	 * IMPORTANT NOTE: DO NOT USE THE CONTEXT OF THE XPATH OBJECT ITSELF INSIDE THE BATCH PROCESSOR!
-	 * 
-	 * Instead, use: Item.getContext(); !!
-	 * 
-	 * 
-	 * @param batchsize
-	 * @param threads
-	 * @param batchProcessor
-	 * @throws CoreException
-	 * @throws InterruptedException
-	 * @throws ExecutionException
-	 */
-	public void batch(int batchsize, int threads, final IBatchProcessor<T> batchProcessor)
-		throws CoreException, InterruptedException, ExecutionException
-	{
-		if (this.sorting.isEmpty())
-			this.addSortingAsc(XPath.ID);
+  public XPath<T> addConstraint() {
+    if (!closeStack.isEmpty() && !closeStack.peek().equals("]"))
+      throw new IllegalStateException("Cannot add a constraint while in the middle of something else..");
 
-		ExecutorService pool = Executors.newFixedThreadPool(threads);
+    return append("][").requireBinOp(false);
+  }
 
-		final long count = this.count();
+  public XPath<T> close() {
+    if (closeStack.isEmpty())
+      throw new IllegalStateException("XPathbuilder close stack is empty!");
+    append(closeStack.pop());
+    return requireBinOp(true);
+    // MWE: note that a close does not necessary require a binary operator, for
+    // example with two subsequent block([bla][boe]) constraints,
+    // but openening a binary constraint reset the flag, so that should be no issue
+  }
 
-		final XPath<T> self = this;
+  public XPath<T> or() {
+    if (!requiresBinOp)
+      throw new IllegalStateException("Received 'or' but no binary operator was expected");
+    return append(" or ").requireBinOp(false);
+  }
 
-		int progress = 0;
-		List<Future<?>> futures = new ArrayList<Future<?>>(batchsize); //no need to synchronize
+  public XPath<T> and() {
+    if (!requiresBinOp)
+      throw new IllegalStateException("Received 'and' but no binary operator was expected");
+    return append(" and ").requireBinOp(false);
+  }
 
-		this.offset(0);
-		this.limit(batchsize);
+  public XPath<T> not() {
+    autoInsertAnd();
+    closeStack.push(")");
+    return append(" not(").requireBinOp(false);
+  }
 
-		List<IMendixObject> data = this.allMendixObjects();
+  private void assertOdd(Object[] stuff) {
+    if (stuff == null || stuff.length == 0 || stuff.length % 2 == 0)
+      throw new IllegalArgumentException("Expected an odd number of xpath path parts");
+  }
 
-		while (data.size() > 0)
-		{
+  private void assertEven(Object[] stuff) {
+    if (stuff == null || stuff.length == 0 || stuff.length % 2 == 1)
+      throw new IllegalArgumentException("Expected an even number of xpath path parts");
+  }
 
-			for (final IMendixObject item : data)
-			{
-				futures.add(pool.submit(new ParallelJobRunner<T>(self, batchProcessor, item, progress, count)));
-				progress += 1;
-			}
+  public XPath<T> append(String s) {
+    builder.append(s);
+    return this;
+  }
 
-			while (!futures.isEmpty())
-				futures.remove(0).get(); //wait for all futures before proceeding to next iteration
+  public String getXPath() {
 
-			this.offset(this.offset + data.size());
-			data = this.allMendixObjects();
-		}
+    if (builder.length() > 0)
+      return "//" + this.entity + "[" + builder.toString() + "]";
+    return "//" + this.entity;
+  }
 
-		if (pool.shutdownNow().size() > 0)
-			throw new IllegalStateException("Not all tasks where finished!");
+  public XPath<T> gt(Object attr, Object valuecomparison) {
+    return compare(attr, ">=", valuecomparison);
+  }
 
-	}
+  public XPath<T> gt(Object... pathAndValue) {
+    assertEven(pathAndValue);
+    return compare(Arrays.copyOfRange(pathAndValue, 0, pathAndValue.length - 1), ">=",
+        pathAndValue[pathAndValue.length - 1]);
+  }
 
-	public static Class<?> getProxyClassForEntityName(String entityname)
-	{
-		{
-			String [] parts = entityname.split("\\.");
-			try
-			{
-				return Class.forName(parts[0].toLowerCase() + ".proxies." +  parts[1]);
-			}
-			catch (ClassNotFoundException e)
-			{
-				throw new RuntimeException("Cannot find class for entity: " + entityname + ": " + e.getMessage(), e);
-			}
-		}
-	}
+  private void assertEmptyStack() throws IllegalStateException {
+    if (!closeStack.isEmpty())
+      throw new IllegalStateException("Invalid xpath expression, not all items where closed");
+  }
 
-	public boolean deleteAll() throws CoreException
-	{
-		this.limit(1000);
-		List<IMendixObject> objs = allMendixObjects();
-		while (!objs.isEmpty()) {
-			if (!Core.delete(context, objs.toArray(new IMendixObject[objs.size()]))) 
-				return false; //TODO: throw?
-			
-			objs = allMendixObjects();
-		}
-		return true;
-	}
+  public long count() throws CoreException {
+    assertEmptyStack();
 
-	// Implement our own ESCAPE_XML because the original got deprecated and we originally translated only a very small
-	// subset of characters.
-	private static final CharSequenceTranslator ESCAPE_XML =
-		new AggregateTranslator(
-			new LookupTranslator(EntityArrays.BASIC_ESCAPE),
-			new LookupTranslator(EntityArrays.APOS_ESCAPE)
-		);
+    return Core.retrieveXPathQueryAggregate(context, "count(" + getXPath() + ")");
+  }
+
+  public IMendixObject firstMendixObject() throws CoreException {
+    assertEmptyStack();
+
+    List<IMendixObject> result = Core.retrieveXPathQuery(context, getXPath(), 1, offset, sorting);
+    if (result.isEmpty())
+      return null;
+    return result.get(0);
+  }
+
+  public T first() throws CoreException {
+    return createProxy(context, proxyClass, firstMendixObject());
+  }
+
+  /**
+   * Given a set of attribute names and values, tries to find the first object
+   * that matches all conditions, or creates one
+   * 
+   * @param keysAndValues
+   * @return
+   * @throws CoreException
+   */
+  public T findOrCreateNoCommit(Object... keysAndValues) throws CoreException {
+    T res = findFirst(keysAndValues);
+
+    return res != null ? res : constructInstance(false, keysAndValues);
+  }
+
+  public T findOrCreate(Object... keysAndValues) throws CoreException {
+    T res = findFirst(keysAndValues);
+
+    return res != null ? res : constructInstance(true, keysAndValues);
+
+  }
+
+  public T findOrCreateSynchronized(Object... keysAndValues) throws CoreException, InterruptedException {
+    T res = findFirst(keysAndValues);
+
+    if (res != null) {
+      return res;
+    } else {
+      synchronized (Core.getMetaObject(entity)) {
+        IContext synchronizedContext = context.getSession().createContext().createSudoClone();
+        try {
+          synchronizedContext.startTransaction();
+          res = createProxy(synchronizedContext, proxyClass,
+              XPath.create(synchronizedContext, entity).findOrCreate(keysAndValues));
+          synchronizedContext.endTransaction();
+          return res;
+        } catch (CoreException e) {
+          if (synchronizedContext.isInTransaction()) {
+            synchronizedContext.rollbackTransaction();
+          }
+          throw e;
+        }
+      }
+    }
+  }
+
+  public T findFirst(Object... keysAndValues)
+      throws IllegalStateException, CoreException {
+    if (builder.length() > 0)
+      throw new IllegalStateException("FindFirst can only be used on XPath which do not have constraints already");
+
+    assertEven(keysAndValues);
+    for (int i = 0; i < keysAndValues.length; i += 2)
+      eq(keysAndValues[i], keysAndValues[i + 1]);
+
+    T res = this.first();
+    return res;
+  }
+
+  /**
+   * Creates one instance of the type of this XPath query, and initializes the
+   * provided attributes to the provided values.
+   * 
+   * @param keysAndValues AttributeName, AttributeValue, AttributeName2,
+   *                      AttributeValue2... list.
+   * @return
+   * @throws CoreException
+   */
+  public T constructInstance(boolean autoCommit, Object... keysAndValues) throws CoreException {
+    assertEven(keysAndValues);
+    IMendixObject newObj = Core.instantiate(context, this.entity);
+
+    for (int i = 0; i < keysAndValues.length; i += 2)
+      newObj.setValue(context, String.valueOf(keysAndValues[i]), toMemberValue(keysAndValues[i + 1]));
+
+    if (autoCommit)
+      Core.commit(context, newObj);
+
+    return createProxy(context, proxyClass, newObj);
+  }
+
+  /**
+   * Given a current collection of primitive values, checks if for each value in
+   * the collection an object in the database exists.
+   * It creates a new object if needed, and removes any superfluos objects in the
+   * database that are no longer in the collection.
+   * 
+   * @param currentCollection   The collection that act as reference for the
+   *                            objects that should be in this database in the
+   *                            end.
+   * @param comparisonAttribute The attribute that should store the value as
+   *                            decribed in the collection
+   * @param autoDelete          Automatically remove any superfluous objects form
+   *                            the database
+   * @param keysAndValues       Constraints that should hold for the set of
+   *                            objects that are deleted or created. Objects
+   *                            outside this constraint are not processed.
+   * 
+   * @return A pair of lists. The first list contains the newly created objects,
+   *         the second list contains the objects that (should be or are) removed.
+   * @throws CoreException
+   */
+  public <U> ImmutablePair<List<T>, List<T>> syncDatabaseWithCollection(Collection<U> currentCollection,
+      Object comparisonAttribute, boolean autoDelete, Object... keysAndValues) throws CoreException {
+    if (builder.length() > 0)
+      throw new IllegalStateException(
+          "syncDatabaseWithCollection can only be used on XPath which do not have constraints already");
+
+    List<T> added = new ArrayList<T>();
+    List<T> removed = new ArrayList<T>();
+
+    Set<U> col = new HashSet<U>(currentCollection);
+
+    for (int i = 0; i < keysAndValues.length; i += 2)
+      eq(keysAndValues[i], keysAndValues[i + 1]);
+
+    for (IMendixObject existingItem : this.allMendixObjects()) {
+      // Item is still available
+      if (col.remove(existingItem.getValue(context, String.valueOf(comparisonAttribute))))
+        continue;
+
+      // No longer available
+      removed.add(createProxy(context, this.proxyClass, existingItem));
+      if (autoDelete)
+        Core.delete(context, existingItem);
+    }
+
+    // Some items where not found in the database
+    for (U value : col) {
+
+      // In apache lang3, this would just be: ArrayUtils.addAll(keysAndValues,
+      // comparisonAttribute, value)
+      Object[] args = new Object[keysAndValues.length + 2];
+      for (int i = 0; i < keysAndValues.length; i++)
+        args[i] = keysAndValues[i];
+      args[keysAndValues.length] = comparisonAttribute;
+      args[keysAndValues.length + 1] = value;
+
+      T newItem = constructInstance(true, args);
+      added.add(newItem);
+    }
+
+    // Oké, stupid, Pair is also only available in apache lang3, so lets use a
+    // simple pair implementation for now
+    return ImmutablePair.of(added, removed);
+  }
+
+  public T firstOrWait(long timeoutMSecs) throws CoreException, InterruptedException {
+    IMendixObject result = null;
+
+    long start = System.currentTimeMillis();
+    int sleepamount = 200;
+    int loopcount = 0;
+
+    while (result == null) {
+      loopcount += 1;
+      result = firstMendixObject();
+
+      long now = System.currentTimeMillis();
+
+      if (start + timeoutMSecs < now) // Time expired
+        break;
+
+      if (loopcount % 5 == 0)
+        sleepamount *= 1.5;
+
+      // not expired, wait a bit
+      if (result == null)
+        Thread.sleep(sleepamount);
+    }
+
+    return createProxy(context, proxyClass, result);
+  }
+
+  public List<IMendixObject> allMendixObjects() throws CoreException {
+    assertEmptyStack();
+
+    return Core.retrieveXPathQuery(context, getXPath(), limit, offset, sorting);
+  }
+
+  public List<T> all() throws CoreException {
+    List<T> res = new ArrayList<T>();
+    for (IMendixObject o : allMendixObjects())
+      res.add(createProxy(context, proxyClass, o));
+
+    return res;
+  }
+
+  @Override
+  public String toString() {
+    return getXPath();
+  }
+
+  /**
+   * 
+   * 
+   * Static utility functions
+   * 
+   * 
+   */
+
+  // cache for proxy constructors. Reflection is slow, so reuse as much as
+  // possible
+  private static Map<String, Method> initializers = new HashMap<String, Method>();
+
+  public static <T> List<T> createProxyList(IContext c, Class<T> proxieClass, List<IMendixObject> objects) {
+    List<T> res = new ArrayList<T>();
+    if (objects == null || objects.size() == 0)
+      return res;
+
+    for (IMendixObject o : objects)
+      res.add(createProxy(c, proxieClass, o));
+
+    return res;
+  }
+
+  public static <T> T createProxy(IContext c, Class<T> proxieClass, IMendixObject object) {
+    // Borrowed from nl.mweststrate.pages.MxQ package
+
+    if (object == null)
+      return null;
+
+    if (c == null || proxieClass == null)
+      throw new IllegalArgumentException("[CreateProxy] No context or proxieClass provided. ");
+
+    // jeuj, we expect IMendixObject's. Thats nice..
+    if (proxieClass == IMendixObject.class)
+      return proxieClass.cast(object); // .. since we can do a direct cast
+
+    try {
+      String entityType = object.getType();
+
+      if (!initializers.containsKey(entityType)) {
+
+        String[] entType = object.getType().split("\\.");
+        Class<?> realClass = Class.forName(entType[0].toLowerCase() + ".proxies." + entType[1]);
+
+        initializers.put(entityType, realClass.getMethod("initialize", IContext.class, IMendixObject.class));
+      }
+
+      // find constructor
+      Method m = initializers.get(entityType);
+
+      // create proxy object
+      Object result = m.invoke(null, c, object);
+
+      // cast, but check first is needed because the actual type might be a subclass
+      // of the requested type
+      if (!proxieClass.isAssignableFrom(result.getClass()))
+        throw new IllegalArgumentException("The type of the object ('" + object.getType()
+            + "') is not (a subclass) of '" + proxieClass.getName() + "'");
+
+      T proxie = proxieClass.cast(result);
+      return proxie;
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to instantiate proxie: " + e.getMessage(), e);
+    }
+  }
+
+  public static String valueToXPathValue(Object value) {
+    if (value == null)
+      return "NULL";
+
+    // Complex objects
+    if (value instanceof IMendixIdentifier)
+      return "'" + String.valueOf(((IMendixIdentifier) value).toLong()) + "'";
+    if (value instanceof IMendixObject)
+      return valueToXPathValue(((IMendixObject) value).getId());
+    if (value instanceof List<?>)
+      throw new IllegalArgumentException("List based values are not supported!");
+
+    // Primitives
+    if (value instanceof Date)
+      return String.valueOf(((Date) value).getTime());
+    if (value instanceof Long || value instanceof Integer)
+      return String.valueOf(value);
+    if (value instanceof Double || value instanceof Float) {
+      // make sure xpath understands our number formatting
+      NumberFormat format = NumberFormat.getNumberInstance(Locale.ENGLISH);
+      format.setMaximumFractionDigits(10);
+      format.setGroupingUsed(false);
+      return format.format(value);
+    }
+    if (value instanceof Boolean) {
+      return value.toString() + "()"; // xpath boolean, you know..
+    }
+    if (value instanceof String) {
+      return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
+    }
+
+    // Object, assume its a proxy and deproxiefy
+    try {
+      IMendixObject mo = proxyToMendixObject(value);
+      return valueToXPathValue(mo);
+    } catch (NoSuchMethodException e) {
+      // This is O.K. just not a proxy object...
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to retrieve MendixObject from proxy: " + e.getMessage(), e);
+    }
+
+    // assume some string representation
+    return "'" + ESCAPE_XML.translate(String.valueOf(value)) + "'";
+  }
+
+  public static IMendixObject proxyToMendixObject(Object value)
+      throws NoSuchMethodException, SecurityException, IllegalAccessException,
+      IllegalArgumentException, InvocationTargetException {
+    Method m = value.getClass().getMethod("getMendixObject");
+    IMendixObject mo = (IMendixObject) m.invoke(value);
+    return mo;
+  }
+
+  public static <T> List<IMendixObject> proxyListToMendixObjectList(
+      List<T> objects) throws SecurityException, IllegalArgumentException, NoSuchMethodException,
+      IllegalAccessException, InvocationTargetException {
+    ArrayList<IMendixObject> res = new ArrayList<IMendixObject>(objects.size());
+    for (T i : objects)
+      res.add(proxyToMendixObject(i));
+    return res;
+  }
+
+  public static Object toMemberValue(Object value) {
+    if (value == null)
+      return null;
+
+    // Complex objects
+    if (value instanceof IMendixIdentifier)
+      return value;
+    if (value instanceof IMendixObject)
+      return ((IMendixObject) value).getId();
+
+    if (value instanceof List<?>)
+      throw new IllegalArgumentException("List based values are not supported!");
+
+    // Primitives
+    if (value instanceof Date
+        || value instanceof Long
+        || value instanceof Integer
+        || value instanceof Double
+        || value instanceof Float
+        || value instanceof Boolean
+        || value instanceof String) {
+      return value;
+    }
+
+    if (value.getClass().isEnum())
+      return value.toString();
+
+    // Object, assume its a proxy and deproxiefy
+    try {
+      Method m = value.getClass().getMethod("getMendixObject");
+      IMendixObject mo = (IMendixObject) m.invoke(value);
+      return toMemberValue(mo);
+    } catch (NoSuchMethodException e) {
+      // This is O.K. just not a proxy object...
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to convert object to IMendixMember compatible value '" + value + "': " + e.getMessage(), e);
+    }
+
+    throw new RuntimeException("Failed to convert object to IMendixMember compatible value: " + value);
+  }
+
+  public static interface IBatchProcessor<T> {
+    public void onItem(T item, long offset, long total) throws Exception;
+  }
+
+  private static final class ParallelJobRunner<T> implements Callable<Boolean> {
+    private final XPath<T> self;
+    private final IBatchProcessor<T> batchProcessor;
+    private final IMendixObject item;
+    private long index;
+    private long count;
+
+    ParallelJobRunner(XPath<T> self, IBatchProcessor<T> batchProcessor, IMendixObject item, long index, long count) {
+      this.self = self;
+      this.batchProcessor = batchProcessor;
+      this.item = item;
+      this.index = index;
+      this.count = count;
+    }
+
+    @Override
+    public Boolean call() {
+      try {
+        batchProcessor.onItem(XPath.createProxy(Core.createSystemContext(), self.proxyClass, item), index, count); // mwe:
+                                                                                                                   // hmm,
+                                                                                                                   // many
+                                                                                                                   // contexts..
+        return true;
+      } catch (Exception e) {
+        throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", self.toString(),
+            self.offset, e.getMessage()), e);
+      }
+    }
+  }
+
+  /**
+   * Retreives all items in this xpath query in batches of a limited size.
+   * Not that this function does not start a new transaction for all the batches,
+   * rather, it just limits the number of objects being retrieved and kept in
+   * memory at the same time.
+   * 
+   * So it only batches the retrieve process, not the optional manipulations done
+   * in the onItem method.
+   * 
+   * @param batchsize
+   * @param batchProcessor
+   * @throws CoreException
+   */
+  public void batch(int batchsize, IBatchProcessor<T> batchProcessor) throws CoreException {
+    if (this.sorting.isEmpty())
+      this.addSortingAsc(XPath.ID);
+
+    long count = this.count();
+
+    int baseoffset = this.offset;
+    int baselimit = this.limit;
+
+    boolean useBaseLimit = baselimit > -1;
+
+    this.offset(baseoffset);
+    List<T> data;
+
+    long i = 0;
+
+    do {
+      int newlimit = useBaseLimit ? Math.min(batchsize, baseoffset + baselimit - this.offset) : batchsize;
+      if (newlimit == 0)
+        break; // where done, no more data is needed
+
+      this.limit(newlimit);
+      data = this.all();
+
+      for (T item : data) {
+        i += 1;
+        try {
+          batchProcessor.onItem(item, i, Math.max(i, count));
+        } catch (Exception e) {
+          throw new RuntimeException(String.format("Failed to execute batch on '%s' offset %d: %s", this.toString(),
+              this.offset, e.getMessage()), e);
+        }
+      }
+
+      this.offset(this.offset + data.size());
+    } while (data.size() > 0);
+  }
+
+  /**
+   * Batch with parallelization.
+   * 
+   * IMPORTANT NOTE: DO NOT USE THE CONTEXT OF THE XPATH OBJECT ITSELF INSIDE THE
+   * BATCH PROCESSOR!
+   * 
+   * Instead, use: Item.getContext(); !!
+   * 
+   * 
+   * @param batchsize
+   * @param threads
+   * @param batchProcessor
+   * @throws CoreException
+   * @throws InterruptedException
+   * @throws ExecutionException
+   */
+  public void batch(int batchsize, int threads, final IBatchProcessor<T> batchProcessor)
+      throws CoreException, InterruptedException, ExecutionException {
+    if (this.sorting.isEmpty())
+      this.addSortingAsc(XPath.ID);
+
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+    final long count = this.count();
+
+    final XPath<T> self = this;
+
+    int progress = 0;
+    List<Future<?>> futures = new ArrayList<Future<?>>(batchsize); // no need to synchronize
+
+    this.offset(0);
+    this.limit(batchsize);
+
+    List<IMendixObject> data = this.allMendixObjects();
+
+    while (data.size() > 0) {
+
+      for (final IMendixObject item : data) {
+        futures.add(pool.submit(new ParallelJobRunner<T>(self, batchProcessor, item, progress, count)));
+        progress += 1;
+      }
+
+      while (!futures.isEmpty())
+        futures.remove(0).get(); // wait for all futures before proceeding to next iteration
+
+      this.offset(this.offset + data.size());
+      data = this.allMendixObjects();
+    }
+
+    if (pool.shutdownNow().size() > 0)
+      throw new IllegalStateException("Not all tasks where finished!");
+
+  }
+
+  public static Class<?> getProxyClassForEntityName(String entityname) {
+    {
+      String[] parts = entityname.split("\\.");
+      try {
+        return Class.forName(parts[0].toLowerCase() + ".proxies." + parts[1]);
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException("Cannot find class for entity: " + entityname + ": " + e.getMessage(), e);
+      }
+    }
+  }
+
+  public boolean deleteAll() throws CoreException {
+    this.limit(1000);
+    List<IMendixObject> objs = allMendixObjects();
+    while (!objs.isEmpty()) {
+      if (!Core.delete(context, objs.toArray(new IMendixObject[objs.size()])))
+        return false; // TODO: throw?
+
+      objs = allMendixObjects();
+    }
+    return true;
+  }
+
+  // Implement our own ESCAPE_XML because the original got deprecated and we
+  // originally translated only a very small
+  // subset of characters.
+  private static final CharSequenceTranslator ESCAPE_XML = new AggregateTranslator(
+      new LookupTranslator(EntityArrays.BASIC_ESCAPE),
+      new LookupTranslator(EntityArrays.APOS_ESCAPE));
 }

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -224,20 +224,29 @@ public class XPath<T> {
   }
 
   public XPath<T> contains(Object attr, String value) {
-    autoInsertAnd().append(" contains(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value))
-        .append(") ");
-    return requireBinOp(true);
+    return functionCall("contains", String.valueOf(attr), valueToXPathValue(value));
   }
 
   public XPath<T> startsWith(Object attr, String value) {
-    autoInsertAnd().append(" starts-with(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value))
-        .append(") ");
-    return requireBinOp(true);
+    return functionCall("starts-with", String.valueOf(attr), valueToXPathValue(value));
   }
 
   public XPath<T> endsWith(Object attr, String value) {
-    autoInsertAnd().append(" ends-with(").append(String.valueOf(attr)).append(",").append(valueToXPathValue(value))
-        .append(") ");
+    return functionCall("ends-with", String.valueOf(attr), valueToXPathValue(value));
+  }
+
+  private XPath<T> functionCall(String functionName, String... args) {
+    autoInsertAnd();
+    append(" " + functionName + "(");
+
+    if (args.length > 0) {
+      append(args[0]);
+      for (int i = 1; i < args.length; i++) {
+        append(",");
+        append(args[i]);
+      }
+    }
+    append(") ");
     return requireBinOp(true);
   }
 

--- a/src/CommunityCommons/javasource/communitycommons/actions/Base64DecodeToFile.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/Base64DecodeToFile.java
@@ -15,8 +15,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Stores an base 64 encoded string plain in the provided target file document
- * 
+ * Stores an base 64 encoded string plain in the provided target file document
+ * 
  * Note that targetFile will be committed.
  */
 public class Base64DecodeToFile extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/Clone.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/Clone.java
@@ -15,12 +15,12 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Clones objects
- * 
- * - Source: the original object to copy
- * - Target: the object to copy it into (should be of the same type, or a specialization)
- * - includeAssociations: whether to clone associations. 
- * 
+ * Clones objects
+ * 
+ * - Source: the original object to copy
+ * - Target: the object to copy it into (should be of the same type, or a specialization)
+ * - includeAssociations: whether to clone associations. 
+ * 
  * If associated objects need to be cloned as well, use deepClone, this function only copies the references, not the reffered objects. Target is not committed automatically.
  */
 public class Clone extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/DeepClone.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/DeepClone.java
@@ -15,24 +15,24 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Clones objects, their associations and even referred objects. 
- * 
- * - Source: the original object to copy
- * - Target: the object to copy it into (should be of the same type, or a specialization)
- * - MembersToSkip: members which should not  be set at all
- * - MembersToKeep: references which should be set, but not cloned. (so source and target will refer to exactly the same object). If an association is not part of this property, it will be cloned.
- * - ReverseAssociations: 1 - 0 assications which refer to target, which will be cloned as well. Only the reference name itself needs to be mentioned.
- * - excludeEntities: entities that will not be cloned. references to these entities will refer to the same object as the source did.
- * - excludeModules: modules that will have none of their enities cloned. Behaves similar to excludeEntities.
- * 
- * members format: <membername> or <module.association> or <module.objecttype/membername>, where objecttype is the concrete type of the object being cloned. 
- * 
- * reverseAssociation: 
- * <module.relation>
- * 
- * membersToSkip by automatically contains createdDate and changedDate. 
- * membersToKeep by automatically contains System.owner and System.changedBy
- * 
+ * Clones objects, their associations and even referred objects. 
+ * 
+ * - Source: the original object to copy
+ * - Target: the object to copy it into (should be of the same type, or a specialization)
+ * - MembersToSkip: members which should not  be set at all
+ * - MembersToKeep: references which should be set, but not cloned. (so source and target will refer to exactly the same object). If an association is not part of this property, it will be cloned.
+ * - ReverseAssociations: 1 - 0 assications which refer to target, which will be cloned as well. Only the reference name itself needs to be mentioned.
+ * - excludeEntities: entities that will not be cloned. references to these entities will refer to the same object as the source did.
+ * - excludeModules: modules that will have none of their enities cloned. Behaves similar to excludeEntities.
+ * 
+ * members format: <membername> or <module.association> or <module.objecttype/membername>, where objecttype is the concrete type of the object being cloned. 
+ * 
+ * reverseAssociation: 
+ * <module.relation>
+ * 
+ * membersToSkip by automatically contains createdDate and changedDate. 
+ * membersToKeep by automatically contains System.owner and System.changedBy
+ * 
  * Note that DeepClone does commit all objects, where Clone does not.
  */
 public class DeepClone extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/Delay.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/Delay.java
@@ -14,8 +14,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Causes this request to sleep for a while. Useful to prevent brute force attacks or to simulate latency delays. 
- *  
+ * Causes this request to sleep for a while. Useful to prevent brute force attacks or to simulate latency delays. 
+ *  
  * Delaytime : time in ms
  */
 public class Delay extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/DuplicateFileDocument.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/DuplicateFileDocument.java
@@ -15,11 +15,11 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Clones the contents of one file document into another. 
- * - fileToClone : the source file
- * - cloneTarget : an initialized file document, in which the file will be stored.
- * 
- * Returns true if copied, returns file if the source had no contents, throws exception in any other case.
+ * Clones the contents of one file document into another. 
+ * - fileToClone : the source file
+ * - cloneTarget : an initialized file document, in which the file will be stored.
+ * 
+ * Returns true if copied, returns file if the source had no contents, throws exception in any other case.
  * Pre condition: HasContents of the 'fileToClone' need to be set to true, otherwise the action will not copy anything.
  */
 public class DuplicateFileDocument extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/DuplicateImageDocument.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/DuplicateImageDocument.java
@@ -15,11 +15,11 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Clones the contents of one image document into another, and generates a thumbnail as well. 
- * - fileToClone : the source file
- * - cloneTarget : an initialized file document, in which the file will be stored.
- * 
- * Returns true if copied, returns file if the source had no contents, throws exception in any other case.
+ * Clones the contents of one image document into another, and generates a thumbnail as well. 
+ * - fileToClone : the source file
+ * - cloneTarget : an initialized file document, in which the file will be stored.
+ * 
+ * Returns true if copied, returns file if the source had no contents, throws exception in any other case.
  * Pre condition: HasContents of the 'fileToClone' need to be set to true, otherwise the action will not copy anything.
  */
 public class DuplicateImageDocument extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/EnumerationFromString.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/EnumerationFromString.java
@@ -16,8 +16,8 @@ import communitycommons.proxies.LogLevel;
 import java.util.Optional;
 
 /**
- * Use this Java action as a template for your own String-to-Enumeration conversions.
- * Studio Pro requires specifying the exact Enumeration to return in the definition of a Java action so we cannot provide a generic implementation.
+ * Use this Java action as a template for your own String-to-Enumeration conversions.
+ * Studio Pro requires specifying the exact Enumeration to return in the definition of a Java action so we cannot provide a generic implementation.
  * This implementation will throw a NoSuchElementException if an invalid toConvert parameter is given, so remember to handle this error gracefully.
  */
 public class EnumerationFromString extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/EscapeHTML.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/EscapeHTML.java
@@ -14,9 +14,9 @@ import com.mendix.webui.CustomJavaAction;
 import communitycommons.StringUtils;
 
 /**
- * Given a, escapes it to html codes, for example
- * 
- * "< Joe & John >" will be converted to 
+ * Given a, escapes it to html codes, for example
+ * 
+ * "< Joe & John >" will be converted to 
  * "&lt; Joe &amp; John &gt;"
  */
 public class EscapeHTML extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/GetCFInstanceIndex.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/GetCFInstanceIndex.java
@@ -14,10 +14,10 @@ import com.mendix.webui.CustomJavaAction;
 import communitycommons.Misc;
 
 /**
- * Returns the Cloud Foundry Instance Index that is set during deployment of the application in a Cloud native environment. Based on the Cloud Foundry Instance Index, Mendix determines what is the leader instance (index 0 executes scheduled events, db sync, session management etc.) or slave instance.
- * 
- * Returns 0 for the leader instance, 1 or higher for slave instances or -1 when the environment variable could not be read (when running locally or on premise). When -1 is returned, it will probably be the leader in the cluster.
- * 
+ * Returns the Cloud Foundry Instance Index that is set during deployment of the application in a Cloud native environment. Based on the Cloud Foundry Instance Index, Mendix determines what is the leader instance (index 0 executes scheduled events, db sync, session management etc.) or slave instance.
+ * 
+ * Returns 0 for the leader instance, 1 or higher for slave instances or -1 when the environment variable could not be read (when running locally or on premise). When -1 is returned, it will probably be the leader in the cluster.
+ * 
  * Make sure emulate cloud security is disabled. Otherwise, the policy restrictions will prevent the method to be executed. Action is tested in Mendix Cloud on 19-12-2018.
  */
 public class GetCFInstanceIndex extends CustomJavaAction<java.lang.Long>

--- a/src/CommunityCommons/javasource/communitycommons/actions/GetIntFromDateTime.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/GetIntFromDateTime.java
@@ -14,11 +14,11 @@ import com.mendix.webui.CustomJavaAction;
 import communitycommons.DateTime;
 
 /**
- * Converts a datetime to an integer based on the selector used.
- * 
- * Selectors available are:
- * - year (returns f. ex. 1980)
- * - month (returns 1-12)
+ * Converts a datetime to an integer based on the selector used.
+ * 
+ * Selectors available are:
+ * - year (returns f. ex. 1980)
+ * - month (returns 1-12)
  * - day (returns 1-31)
  */
 public class GetIntFromDateTime extends CustomJavaAction<java.lang.Long>

--- a/src/CommunityCommons/javasource/communitycommons/actions/HTMLEncode.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/HTMLEncode.java
@@ -14,11 +14,11 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Encodes a string to HTML Entities, so that they can be displayed in the browser without breaking any layout. 
- * 
- * This is useful for special widgets which allow HTML to be rendered properly, including special characters as '<' and '&'. 
- * For example '<' will be encoded as '&lt;' and '&' will be encoded as '&amp;'
- * 
+ * Encodes a string to HTML Entities, so that they can be displayed in the browser without breaking any layout. 
+ * 
+ * This is useful for special widgets which allow HTML to be rendered properly, including special characters as '<' and '&'. 
+ * For example '<' will be encoded as '&lt;' and '&' will be encoded as '&amp;'
+ * 
  * Returns the encoded string.
  */
 public class HTMLEncode extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/HTMLToPlainText.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/HTMLToPlainText.java
@@ -14,7 +14,7 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Use this function to convert HTML text to plain text. 
+ * Use this function to convert HTML text to plain text. 
  * It will preserve linebreaks but strip all other markup. including html entity decoding.
  */
 public class HTMLToPlainText extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/Hash.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/Hash.java
@@ -14,11 +14,11 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Hashes a value using the SHA-256 hash algorithm. 
- * 
- * - value : the value to hash
- * - length : the desired length of the hash. 
- * 
+ * Hashes a value using the SHA-256 hash algorithm. 
+ * 
+ * - value : the value to hash
+ * - length : the desired length of the hash. 
+ * 
  * Returns a SHA-256 hash of 'value', with length 'length'
  */
 public class Hash extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/MonthsBetween.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/MonthsBetween.java
@@ -18,8 +18,8 @@ import communitycommons.proxies.LogNodes;
 import java.util.Date;
 
 /**
- * Calculates the number of months between two dates. 
- * - dateTime : the original (oldest) dateTime
+ * Calculates the number of months between two dates. 
+ * - dateTime : the original (oldest) dateTime
  * - compareDate: the second date. If EMPTY, the current datetime will be used. Effectively this means that the age of the dateTime is calculated.
  */
 public class MonthsBetween extends CustomJavaAction<java.lang.Long>

--- a/src/CommunityCommons/javasource/communitycommons/actions/ParseDateTimeWithTimezone.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/ParseDateTimeWithTimezone.java
@@ -19,7 +19,7 @@ import communitycommons.proxies.LogNodes;
 import java.text.ParseException;
 
 /**
- * This method parses a date from a string with a given pattern according to a specific timezone.
+ * This method parses a date from a string with a given pattern according to a specific timezone.
  * The timezone has to be a valid timezone id http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html (e.g. one of https://garygregory.wordpress.com/2013/06/18/what-are-the-java-timezone-ids/) 
  */
 public class ParseDateTimeWithTimezone extends CustomJavaAction<java.util.Date>

--- a/src/CommunityCommons/javasource/communitycommons/actions/RandomStrongPassword.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/RandomStrongPassword.java
@@ -14,8 +14,8 @@ import com.mendix.webui.CustomJavaAction;
 import communitycommons.StringUtils;
 
 /**
- * Returns a random strong password containing a specified minimum number of digits, uppercase and special characters.
- * 
+ * Returns a random strong password containing a specified minimum number of digits, uppercase and special characters.
+ * 
  * Note:Minimumlength should be equal or larger than NrOfCapitalizedCharacters, NrOfDigits and NrOfSpecialCharacters
  */
 public class RandomStrongPassword extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/RegexReplaceAll.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/RegexReplaceAll.java
@@ -14,12 +14,12 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Performs a regular expression. Similar to the replaceAll microflow function, but supports more advanced usages such as capture variables.
- * 
- * For the regexp specification see:
- * https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
- * 
- * A decent regexp tester can be found at:
+ * Performs a regular expression. Similar to the replaceAll microflow function, but supports more advanced usages such as capture variables.
+ * 
+ * For the regexp specification see:
+ * https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+ * 
+ * A decent regexp tester can be found at:
  * http://www.fileformat.info/tool/regex.htm
  */
 public class RegexReplaceAll extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/RunMicroflowAsyncInQueue.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/RunMicroflowAsyncInQueue.java
@@ -14,8 +14,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Runs a microflow asynchronous, that is, this action immediately returns but schedules the microflow to be run in the near future. The queue guarantees a first come first serve order of the microflows, and only one action is served at a time.
- * 
+ * Runs a microflow asynchronous, that is, this action immediately returns but schedules the microflow to be run in the near future. The queue guarantees a first come first serve order of the microflows, and only one action is served at a time.
+ * 
  * The microflow is run with system rights in its own transaction, and is very useful to run heavy microflows on the background.
  */
 public class RunMicroflowAsyncInQueue extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/StringLeftPad.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/StringLeftPad.java
@@ -13,13 +13,13 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Pads a string on the left to a certain length. 
- * value : the original value
- * amount: the desired length of the resulting string.
- * fillCharacter: the character to pad with. (or space if empty)
- * 
- * For example
- * StringLeftPad("hello", 8, "-")  returns "---hello"
+ * Pads a string on the left to a certain length. 
+ * value : the original value
+ * amount: the desired length of the resulting string.
+ * fillCharacter: the character to pad with. (or space if empty)
+ * 
+ * For example
+ * StringLeftPad("hello", 8, "-")  returns "---hello"
  * StringLeftPad("hello", 2, "-")  returns "hello"
  */
 public class StringLeftPad extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/StringRightPad.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/StringRightPad.java
@@ -13,13 +13,13 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Pads a string on the right to a certain length. 
- * value : the original value
- * amount: the desired length of the resulting string.
- * fillCharacter: the character to pad with. (or space if empty)
- * 
- * For example
- * StringRightPad("hello", 8, "-")  returns "hello---"
+ * Pads a string on the right to a certain length. 
+ * value : the original value
+ * amount: the desired length of the resulting string.
+ * fillCharacter: the character to pad with. (or space if empty)
+ * 
+ * For example
+ * StringRightPad("hello", 8, "-")  returns "hello---"
  * StringLeftpad("hello", 2, "-")  returns "hello"
  */
 public class StringRightPad extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/StringToFile.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/StringToFile.java
@@ -17,7 +17,7 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Stores a string into the provided FileDocument, using the specified encoding.
+ * Stores a string into the provided FileDocument, using the specified encoding.
  * Note that destination will be committed.
  */
 public class StringToFile extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/StringTrim.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/StringTrim.java
@@ -13,7 +13,7 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Left and right trims a string (that is; removes all surrounding whitespace characters such as tabs, spaces and returns). 
+ * Left and right trims a string (that is; removes all surrounding whitespace characters such as tabs, spaces and returns). 
  * Returns the empty string if value is the empty value. Returns the trimmed string otherwise.
  */
 public class StringTrim extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/SubstituteTemplate.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/SubstituteTemplate.java
@@ -15,21 +15,21 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Given an object and a template, substitutes all fields in the template. Supports attributes, references, referencesets and constants. 
- * 
- * The general field syntax is '{fieldname}'. 
- * 
- * Fieldname can be a member of the example object, an attribute which need to be retrieved over an reference(set) or a project constant. All paths are relative from the provided substitute obect. An example template:
- * ------------------
- * Dear {EmailOrName},
- * 
- * {System.changedBy/FullName} has invited you to join the project {Module.MemberShip_Project/Name}. 
- * Sign up is free and can be done here:
- * {@Module.PublicURL}link/Signup
- * -------------------------
- * 
- * useHTMLEncoding identifies whether HTMLEncode is applied to the values before substituting.
- * 
+ * Given an object and a template, substitutes all fields in the template. Supports attributes, references, referencesets and constants. 
+ * 
+ * The general field syntax is '{fieldname}'. 
+ * 
+ * Fieldname can be a member of the example object, an attribute which need to be retrieved over an reference(set) or a project constant. All paths are relative from the provided substitute obect. An example template:
+ * ------------------
+ * Dear {EmailOrName},
+ * 
+ * {System.changedBy/FullName} has invited you to join the project {Module.MemberShip_Project/Name}. 
+ * Sign up is free and can be done here:
+ * {@Module.PublicURL}link/Signup
+ * -------------------------
+ * 
+ * useHTMLEncoding identifies whether HTMLEncode is applied to the values before substituting.
+ * 
  * datetimeformat identifies a format string which is applied to date/time based attributes. Can be left empty. Defaults to "EEE dd MMM yyyy, HH:mm"
  */
 public class SubstituteTemplate extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/SubstituteTemplate2.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/SubstituteTemplate2.java
@@ -15,8 +15,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Identical to SubstituteTemplate, but adds an datetimeformat argument
- * 
+ * Identical to SubstituteTemplate, but adds an datetimeformat argument
+ * 
  * DateTimeFormat identifies a format string which is applied to date/time based attributes. Can be left empty. Defaults to "EEE dd MMM yyyy, HH:mm"
  */
 public class SubstituteTemplate2 extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/ThrowException.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/ThrowException.java
@@ -14,10 +14,10 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * This action always throws an exception (of type communityutils.UserThrownError), which is, in combination with custom error handling, quite useful to end a microflow prematurely or to bail out to the calling action/ microflow. 
- * 
- * The message of the last thrown error can be inspected by using the variable $lasterrormessage
- * 
+ * This action always throws an exception (of type communityutils.UserThrownError), which is, in combination with custom error handling, quite useful to end a microflow prematurely or to bail out to the calling action/ microflow. 
+ * 
+ * The message of the last thrown error can be inspected by using the variable $lasterrormessage
+ * 
  * Example usuage: In general, if an Event (before commit especially) returns false, it should call this action and then return true instead. If an Before commit returns false, the object will not be committed, but there is no easy way for the calling Microflow/ action to detect this! An exception on the other hand, will be noticed.
  */
 public class ThrowException extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/ThrowWebserviceException.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/ThrowWebserviceException.java
@@ -14,10 +14,10 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * (Behavior has changed since version 3.2. The exception is now properly propagated to the cient). 
- * 
- * Throws an exception.  This is very useful if the microflow is called by a webservice. If you throw this kind of exceptions, an fault message will be generated in the output, instead of an '501 Internal server' error.
- * 
+ * (Behavior has changed since version 3.2. The exception is now properly propagated to the cient). 
+ * 
+ * Throws an exception.  This is very useful if the microflow is called by a webservice. If you throw this kind of exceptions, an fault message will be generated in the output, instead of an '501 Internal server' error.
+ * 
  * If debug level of community commons is set to 'debug' the errors will be locally visible as well, otherwise not. Throwing a webservice exception states that the webservice invocation was incorrect, not the webservice implementation.
  */
 public class ThrowWebserviceException extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/TimeMeasureEnd.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/TimeMeasureEnd.java
@@ -14,9 +14,9 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * End timing something, and print the result to the log. 
- * - TimerName. Should correspond to the TimerName used with TimeMeasureStart.
- * - LogLevel. The loglevel used to print the result.
+ * End timing something, and print the result to the log. 
+ * - TimerName. Should correspond to the TimerName used with TimeMeasureStart.
+ * - LogLevel. The loglevel used to print the result.
  * - The message to be printed in the log.
  */
 public class TimeMeasureEnd extends CustomJavaAction<java.lang.Long>

--- a/src/CommunityCommons/javasource/communitycommons/actions/TimeMeasureStart.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/TimeMeasureStart.java
@@ -14,9 +14,9 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Start timing something, and print the result to the log. 
- * - TimerName. Should correspond to the TimerName used in TimeMeasureEnd.
- * 
+ * Start timing something, and print the result to the log. 
+ * - TimerName. Should correspond to the TimerName used in TimeMeasureEnd.
+ * 
  * Note that multiple timers can run at once. Existing timers can be restarted using this function as well.
  */
 public class TimeMeasureStart extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/XSSSanitize.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/XSSSanitize.java
@@ -20,22 +20,22 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Removes all potential dangerous HTML from a string so that it can be safely displayed in a browser. 
- * 
- * This function should be applied to all HTML which is displayed in the browser, and can be entered by (untrusted) users.
- * 
- * - HTML: The html to sanitize
- * - policy1... policy6: one or more values of SanitizerPolicy. You may leave these policy parameters empty if you don't want to allow additional elements.
- * 
- * BLOCKS: Allows common block elements including <p>, <h1>, etc.
- * FORMATTING: Allows common formatting elements including <b>, <i>, etc.
- * IMAGES: Allows <img> elements from HTTP, HTTPS, and relative sources.
- * LINKS: Allows HTTP, HTTPS, MAILTO and relative links
- * STYLES: Allows certain safe CSS properties in style="..." attributes.
- * TABLES: Allows commons table elements.
- * 
- * For more information, visit:
- * 
+ * Removes all potential dangerous HTML from a string so that it can be safely displayed in a browser. 
+ * 
+ * This function should be applied to all HTML which is displayed in the browser, and can be entered by (untrusted) users.
+ * 
+ * - HTML: The html to sanitize
+ * - policy1... policy6: one or more values of SanitizerPolicy. You may leave these policy parameters empty if you don't want to allow additional elements.
+ * 
+ * BLOCKS: Allows common block elements including <p>, <h1>, etc.
+ * FORMATTING: Allows common formatting elements including <b>, <i>, etc.
+ * IMAGES: Allows <img> elements from HTTP, HTTPS, and relative sources.
+ * LINKS: Allows HTTP, HTTPS, MAILTO and relative links
+ * STYLES: Allows certain safe CSS properties in style="..." attributes.
+ * TABLES: Allows commons table elements.
+ * 
+ * For more information, visit:
+ * 
  * http://javadoc.io/doc/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/20180219.1
  */
 public class XSSSanitize extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/YearsBetween.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/YearsBetween.java
@@ -18,8 +18,8 @@ import communitycommons.proxies.LogNodes;
 import java.util.Date;
 
 /**
- * Calculates the number of years between two dates. 
- * - dateTime : the original (oldest) dateTime
+ * Calculates the number of years between two dates. 
+ * - dateTime : the original (oldest) dateTime
  * - compareDate: the second date. If EMPTY, the current datetime will be used. Effectively this means that the age of the dateTime is calculated.
  */
 public class YearsBetween extends CustomJavaAction<java.lang.Long>

--- a/src/CommunityCommons/javasource/communitycommons/actions/commitWithoutEvents.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/commitWithoutEvents.java
@@ -15,8 +15,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Commits an object, but without events. 
- * 
+ * Commits an object, but without events. 
+ * 
  * N.B. This function is not very useful when called from the model, but it is useful when called from custom Java code.
  */
 public class commitWithoutEvents extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/copyAttributes.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/copyAttributes.java
@@ -15,8 +15,8 @@ import com.mendix.systemwideinterfaces.core.IMendixObject;
 import communitycommons.ORM;
 
 /**
- * Copies all common primitive attributes from source to target, which are not necessarily of the same type. This is useful to, for example, translate database object into view objects.
- * 
+ * Copies all common primitive attributes from source to target, which are not necessarily of the same type. This is useful to, for example, translate database object into view objects.
+ * 
  * Note that no automatic type conversion is done. 
  */
 public class copyAttributes extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/executeMicroflowAsUser.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/executeMicroflowAsUser.java
@@ -14,10 +14,10 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Executes the given microflow as if the $currentuser is the provided user (delegation). Use sudoContext to determine if 'apply entity access' should be used 
- * 
- * - microflowName: the fully qualified microflow name, 'CommunityCommons.CreateUserIfNotExists'
- * - username: The user that should be used to execute the microflow
+ * Executes the given microflow as if the $currentuser is the provided user (delegation). Use sudoContext to determine if 'apply entity access' should be used 
+ * 
+ * - microflowName: the fully qualified microflow name, 'CommunityCommons.CreateUserIfNotExists'
+ * - username: The user that should be used to execute the microflow
  * - sudoContext: whether entity access should be applied.
  */
 public class executeMicroflowAsUser extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/executeMicroflowInBackground.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/executeMicroflowInBackground.java
@@ -15,18 +15,18 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * This action allows an microflow to be executed independently from this microflow. 
- * This function is identical to "RunMicroflowAsyncInQueue", except that it takes one argument which will be passed to the microflow being called. 
- * 
- * This might be useful to model for example your own batching system, or to run a microflow in its own (system) transaction. The microflow is delayed for at least 200ms and then run with low priority in a system context. Since the microflow run in its own transaction, it is not affected with rollbacks (due to exceptions) or commits in this microflow. 
- * 
- * Invocations to this method are guaranteed to be run in FIFO order, only one microflow is run at a time. 
- * 
- * Note that since the microflow is run as system transaction, $currentUser is not available and no security restrictions are applied. 
- * 
- * - The microflowname specifies the fully qualified name of the microflow (case sensitive) e.g.: 'MyFirstModule.MyFirstMicroflow'. 
- * - The context object specifies an argument that should be passed to the microflow if applicable. Currently only zero or one argument are supported. Note that editing this object in both microflows might lead to unexpected behavior.
- * 
+ * This action allows an microflow to be executed independently from this microflow. 
+ * This function is identical to "RunMicroflowAsyncInQueue", except that it takes one argument which will be passed to the microflow being called. 
+ * 
+ * This might be useful to model for example your own batching system, or to run a microflow in its own (system) transaction. The microflow is delayed for at least 200ms and then run with low priority in a system context. Since the microflow run in its own transaction, it is not affected with rollbacks (due to exceptions) or commits in this microflow. 
+ * 
+ * Invocations to this method are guaranteed to be run in FIFO order, only one microflow is run at a time. 
+ * 
+ * Note that since the microflow is run as system transaction, $currentUser is not available and no security restrictions are applied. 
+ * 
+ * - The microflowname specifies the fully qualified name of the microflow (case sensitive) e.g.: 'MyFirstModule.MyFirstMicroflow'. 
+ * - The context object specifies an argument that should be passed to the microflow if applicable. Currently only zero or one argument are supported. Note that editing this object in both microflows might lead to unexpected behavior.
+ * 
  * Returns true if scheduled successfully.
  */
 public class executeMicroflowInBackground extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/executeMicroflowInBatches.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/executeMicroflowInBatches.java
@@ -14,21 +14,21 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Invokes a microflow in batches. The microflow is invoked for each individual item returned by the xpath query. 
- * 
- * The objects will be processed in small batches (based on the batchsize), which makes this function very useful to process large amounts of objects without using much memory. All defaut behavior such as commit events are applied as defined in your microflow. 
- * 
- * Parameters:
- * - xpath: Fully qualified xpath query that indicates the set of objects the microflow should be invoked on. For example:
- * '//System.User[Active = true()]'
- * - microflow: The microflow that should be invoked. Should accept one argument of the same type as the xpath. For example:
- * 'MyFirstModule.UpdateBirthday'
- * - batchsize: The amount of objects that should be processed in a single transaction. When in doubt, 1 is fine, but larger batches (for example; 100) will be faster due to less overhead.
- * - waitUntilFinished: Whether this call should block (wait) until all objects are
- *  processed.
- * 
- * Returns true if the batch has successfully started, or, if waitUntilFinished is true, returns true if the batch succeeded completely. 
- * 
+ * Invokes a microflow in batches. The microflow is invoked for each individual item returned by the xpath query. 
+ * 
+ * The objects will be processed in small batches (based on the batchsize), which makes this function very useful to process large amounts of objects without using much memory. All defaut behavior such as commit events are applied as defined in your microflow. 
+ * 
+ * Parameters:
+ * - xpath: Fully qualified xpath query that indicates the set of objects the microflow should be invoked on. For example:
+ * '//System.User[Active = true()]'
+ * - microflow: The microflow that should be invoked. Should accept one argument of the same type as the xpath. For example:
+ * 'MyFirstModule.UpdateBirthday'
+ * - batchsize: The amount of objects that should be processed in a single transaction. When in doubt, 1 is fine, but larger batches (for example; 100) will be faster due to less overhead.
+ * - waitUntilFinished: Whether this call should block (wait) until all objects are
+ *  processed.
+ * 
+ * Returns true if the batch has successfully started, or, if waitUntilFinished is true, returns true if the batch succeeded completely. 
+ * 
  * Note, if new objects are added to the dataset while the batch is still running, those objects will be processed as well.
  */
 public class executeMicroflowInBatches extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/executeUnverifiedMicroflowAsUser.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/executeUnverifiedMicroflowAsUser.java
@@ -14,10 +14,10 @@ import com.mendix.webui.CustomJavaAction;
 import communitycommons.Misc;
 
 /**
- * Executes the given microflow as if the $currentuser is the provided user (delegation). Use sudoContext to determine if 'apply entity access' should be used 
- * 
- * - microflowName: the fully qualified microflow name, 'CommunityCommons.CreateUserIfNotExists'
- * - username: The user that should be used to execute the microflow
+ * Executes the given microflow as if the $currentuser is the provided user (delegation). Use sudoContext to determine if 'apply entity access' should be used 
+ * 
+ * - microflowName: the fully qualified microflow name, 'CommunityCommons.CreateUserIfNotExists'
+ * - username: The user that should be used to execute the microflow
  * - sudoContext: whether entity access should be applied.
  */
 public class executeUnverifiedMicroflowAsUser extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/executeUnverifiedMicroflowInBackground.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/executeUnverifiedMicroflowInBackground.java
@@ -15,18 +15,18 @@ import communitycommons.Misc;
 import com.mendix.systemwideinterfaces.core.IMendixObject;
 
 /**
- * This action allows an microflow to be executed independently from this microflow. 
- * This function is identical to "RunMicroflowAsyncInQueue", except that it takes one argument which will be passed to the microflow being called. 
- * 
- * This might be useful to model for example your own batching system, or to run a microflow in its own (system) transaction. The microflow is delayed for at least 200ms and then run with low priority in a system context. Since the microflow run in its own transaction, it is not affected with rollbacks (due to exceptions) or commits in this microflow. 
- * 
- * Invocations to this method are guaranteed to be run in FIFO order, only one microflow is run at a time. 
- * 
- * Note that since the microflow is run as system transaction, $currentUser is not available and no security restrictions are applied. 
- * 
- * - The microflowname specifies the fully qualified name of the microflow (case sensitive) e.g.: 'MyFirstModule.MyFirstMicroflow'. 
- * - The context object specifies an argument that should be passed to the microflow if applicable. Currently only zero or one argument are supported. Note that editing this object in both microflows might lead to unexpected behavior.
- * 
+ * This action allows an microflow to be executed independently from this microflow. 
+ * This function is identical to "RunMicroflowAsyncInQueue", except that it takes one argument which will be passed to the microflow being called. 
+ * 
+ * This might be useful to model for example your own batching system, or to run a microflow in its own (system) transaction. The microflow is delayed for at least 200ms and then run with low priority in a system context. Since the microflow run in its own transaction, it is not affected with rollbacks (due to exceptions) or commits in this microflow. 
+ * 
+ * Invocations to this method are guaranteed to be run in FIFO order, only one microflow is run at a time. 
+ * 
+ * Note that since the microflow is run as system transaction, $currentUser is not available and no security restrictions are applied. 
+ * 
+ * - The microflowname specifies the fully qualified name of the microflow (case sensitive) e.g.: 'MyFirstModule.MyFirstMicroflow'. 
+ * - The context object specifies an argument that should be passed to the microflow if applicable. Currently only zero or one argument are supported. Note that editing this object in both microflows might lead to unexpected behavior.
+ * 
  * Returns true if scheduled successfully.
  */
 public class executeUnverifiedMicroflowInBackground extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/executeUnverifiedMicroflowInBatches.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/executeUnverifiedMicroflowInBatches.java
@@ -14,21 +14,21 @@ import com.mendix.webui.CustomJavaAction;
 import communitycommons.Misc;
 
 /**
- * Invokes a microflow in batches. The microflow is invoked for each individual item returned by the xpath query. 
- * 
- * The objects will be processed in small batches (based on the batchsize), which makes this function very useful to process large amounts of objects without using much memory. All defaut behavior such as commit events are applied as defined in your microflow. 
- * 
- * Parameters:
- * - xpath: Fully qualified xpath query that indicates the set of objects the microflow should be invoked on. For example:
- * '//System.User[Active = true()]'
- * - microflow: The microflow that should be invoked. Should accept one argument of the same type as the xpath. For example:
- * 'MyFirstModule.UpdateBirthday'
- * - batchsize: The amount of objects that should be processed in a single transaction. When in doubt, 1 is fine, but larger batches (for example; 100) will be faster due to less overhead.
- * - waitUntilFinished: Whether this call should block (wait) until all objects are
- *  processed.
- * 
- * Returns true if the batch has successfully started, or, if waitUntilFinished is true, returns true if the batch succeeded completely. 
- * 
+ * Invokes a microflow in batches. The microflow is invoked for each individual item returned by the xpath query. 
+ * 
+ * The objects will be processed in small batches (based on the batchsize), which makes this function very useful to process large amounts of objects without using much memory. All defaut behavior such as commit events are applied as defined in your microflow. 
+ * 
+ * Parameters:
+ * - xpath: Fully qualified xpath query that indicates the set of objects the microflow should be invoked on. For example:
+ * '//System.User[Active = true()]'
+ * - microflow: The microflow that should be invoked. Should accept one argument of the same type as the xpath. For example:
+ * 'MyFirstModule.UpdateBirthday'
+ * - batchsize: The amount of objects that should be processed in a single transaction. When in doubt, 1 is fine, but larger batches (for example; 100) will be faster due to less overhead.
+ * - waitUntilFinished: Whether this call should block (wait) until all objects are
+ *  processed.
+ * 
+ * Returns true if the batch has successfully started, or, if waitUntilFinished is true, returns true if the batch succeeded completely. 
+ * 
  * Note, if new objects are added to the dataset while the batch is still running, those objects will be processed as well.
  */
 public class executeUnverifiedMicroflowInBatches extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/getCreatedByUser.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/getCreatedByUser.java
@@ -15,8 +15,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Returns the user that created an object 
- * 
+ * Returns the user that created an object 
+ * 
  * (or empty if not applicable).
  */
 public class getCreatedByUser extends CustomJavaAction<IMendixObject>

--- a/src/CommunityCommons/javasource/communitycommons/actions/getFileSize.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/getFileSize.java
@@ -15,11 +15,11 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Returns the filesize of a file document in bytes.
- * 
- * From version 2.3 on, this function can be used in cloud environments as well. 
- * 
- * NOTE:
+ * Returns the filesize of a file document in bytes.
+ * 
+ * From version 2.3 on, this function can be used in cloud environments as well. 
+ * 
+ * NOTE:
  * before 2.1, this functioned returned the size in kilobytes, although this documentation mentioned bytes
  */
 public class getFileSize extends CustomJavaAction<java.lang.Long>

--- a/src/CommunityCommons/javasource/communitycommons/actions/getLastChangedByUser.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/getLastChangedByUser.java
@@ -15,8 +15,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Returns the user that last changed this object as System.User 
- * 
+ * Returns the user that last changed this object as System.User 
+ * 
  * (or empty if not applicable).
  */
 public class getLastChangedByUser extends CustomJavaAction<IMendixObject>

--- a/src/CommunityCommons/javasource/communitycommons/actions/getOriginalValueAsString.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/getOriginalValueAsString.java
@@ -15,12 +15,12 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Returns the original value of an object member, that is, the last committed value.
- * 
- * This is useful if you want to compare the actual value with the last stored value. 
- * - item : the object of which you want to inspect a member
- * - member: the member to retrieve the previous value from. Note that for references, the module name needs to be included.
- * 
+ * Returns the original value of an object member, that is, the last committed value.
+ * 
+ * This is useful if you want to compare the actual value with the last stored value. 
+ * - item : the object of which you want to inspect a member
+ * - member: the member to retrieve the previous value from. Note that for references, the module name needs to be included.
+ * 
  * The function is applicable for non-String members as well, but always returns a String representation of the previous value.
  */
 public class getOriginalValueAsString extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/memberHasChanged.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/memberHasChanged.java
@@ -15,11 +15,11 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Checks whether a member has changed since the last commit. Useful in combination with getOriginalValueAsString.
- * 
- * - item : the object to inspect
- * - member: the name of the member to inspect. Note that for references, the module name needs to be included.
- * 
+ * Checks whether a member has changed since the last commit. Useful in combination with getOriginalValueAsString.
+ * 
+ * - item : the object to inspect
+ * - member: the name of the member to inspect. Note that for references, the module name needs to be included.
+ * 
  * Returns true if changed.
  */
 public class memberHasChanged extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/objectHasChanged.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/objectHasChanged.java
@@ -15,8 +15,8 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Returns true if at least one member (including owned associations) of this object has changed.
- * 
+ * Returns true if at least one member (including owned associations) of this object has changed.
+ * 
  * For Mendix < 9.5 this action keeps track of changes to the object except when 'changing to the same value'. For Mendix >= 9.5 this action keeps track of all changes. This is a result of a change of the underlying Mendix runtime-server behaviour. 
  */
 public class objectHasChanged extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/refreshClass.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/refreshClass.java
@@ -14,9 +14,9 @@ import com.mendix.webui.CustomJavaAction;
 import com.mendix.webui.FeedbackHelper;
 
 /**
- * Refreshes a certain domain object type in the client. Useful to enforce a datagrid to refresh for example.
- * 
- * -objectType : Type of the domain objects to refresh, such as System.User or MyModule.MyFirstEntity.
+ * Refreshes a certain domain object type in the client. Useful to enforce a datagrid to refresh for example.
+ * 
+ * -objectType : Type of the domain objects to refresh, such as System.User or MyModule.MyFirstEntity.
  *  (you can use getTypeAsString to determine this dynamically, so that the invoke of this action is not be sensitive to domain model changes).
  */
 public class refreshClass extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/refreshClassByObject.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/refreshClassByObject.java
@@ -15,8 +15,8 @@ import com.mendix.webui.CustomJavaAction;
 import com.mendix.webui.FeedbackHelper;
 
 /**
- * Refreshes a certain domain object type in the client. Useful to enforce a datagrid to refresh for example.
- * 
+ * Refreshes a certain domain object type in the client. Useful to enforce a datagrid to refresh for example.
+ * 
  * - instance : This object is used to identify the type of objects that need to be refreshed. For example passing $currentUser will refresh all System.Account's.
  */
 public class refreshClassByObject extends CustomJavaAction<java.lang.Boolean>

--- a/src/CommunityCommons/javasource/communitycommons/actions/retrieveURL.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/retrieveURL.java
@@ -14,16 +14,16 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Retrieves data (such as an HTML page) from an URL using the HTTP protocol, and returns it as string. 
- * 
- * - url : The URL to retrieve. 
- * - post : Data to be sent in the request body. If set, a POST request will be send, otherwise a GET request is used. 
- * 
- * Example urls: 
- * 'https://mxforum.mendix.com/search/'
- * 'http://www.google.nl/#hl=nl&q=download+mendix'
- * 
- * Example post data: 
+ * Retrieves data (such as an HTML page) from an URL using the HTTP protocol, and returns it as string. 
+ * 
+ * - url : The URL to retrieve. 
+ * - post : Data to be sent in the request body. If set, a POST request will be send, otherwise a GET request is used. 
+ * 
+ * Example urls: 
+ * 'https://mxforum.mendix.com/search/'
+ * 'http://www.google.nl/#hl=nl&q=download+mendix'
+ * 
+ * Example post data: 
  * 'ipSearchTag=url&x=0&y=0'
  */
 public class retrieveURL extends CustomJavaAction<java.lang.String>

--- a/src/CommunityCommons/javasource/communitycommons/actions/storeURLToFileDocument.java
+++ b/src/CommunityCommons/javasource/communitycommons/actions/storeURLToFileDocument.java
@@ -15,13 +15,13 @@ import com.mendix.systemwideinterfaces.core.IContext;
 import com.mendix.webui.CustomJavaAction;
 
 /**
- * Retrieve a document from an URL using a HTTP GET request. 
- * - url : the URL to retrieve 
- * - document: the document to store the data into
- * - filename: the filename to store it under. Only for internal use, so it can be an arbitrary filename. 
- * 
- * Example URL: 'http://www.mendix.com/wordpress/wp-content/themes/mendix_new/images/mendix.png'
- * 
+ * Retrieve a document from an URL using a HTTP GET request. 
+ * - url : the URL to retrieve 
+ * - document: the document to store the data into
+ * - filename: the filename to store it under. Only for internal use, so it can be an arbitrary filename. 
+ * 
+ * Example URL: 'http://www.mendix.com/wordpress/wp-content/themes/mendix_new/images/mendix.png'
+ * 
  * NOTE: For images, no thumbnail will be generated.
  */
 public class storeURLToFileDocument extends CustomJavaAction<java.lang.Boolean>

--- a/src/test/communitycommons/XPathTest.java
+++ b/src/test/communitycommons/XPathTest.java
@@ -1,0 +1,304 @@
+package communitycommons;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import com.mendix.core.CoreException;
+import com.mendix.core.objectmanagement.member.MendixObjectReference;
+import com.mendix.core.objectmanagement.member.MendixObjectReferenceSet;
+import com.mendix.systemwideinterfaces.core.IContext;
+import com.mendix.systemwideinterfaces.core.IMendixIdentifier;
+import com.mendix.systemwideinterfaces.core.IMendixObject;
+import com.mendix.systemwideinterfaces.core.IMendixObjectMember;
+import com.mendix.systemwideinterfaces.core.meta.IMetaObject;
+
+public class XPathTest {
+
+  @Test
+  public void valueToXPathValue() throws Exception {
+    assertEquals("NULL", XPath.valueToXPathValue(null));
+    assertEquals("42", XPath.valueToXPathValue(42));
+    assertEquals("42.42", XPath.valueToXPathValue(42.42));
+    assertEquals("'string'", XPath.valueToXPathValue("string"));
+    assertEquals("true()", XPath.valueToXPathValue(true));
+    assertEquals("false()", XPath.valueToXPathValue(false));
+
+    var d = new Date();
+    assertEquals("" + d.getTime(), XPath.valueToXPathValue(d));
+
+    var id = new TestIdentifier(123);
+    assertEquals("'123'", XPath.valueToXPathValue(id));
+
+    var obj = new TestObject(id);
+    assertEquals("'123'", XPath.valueToXPathValue(obj));
+
+    var proxy = new TestProxy(obj);
+    assertEquals("'123'", XPath.valueToXPathValue(proxy));
+  }
+
+  // XPath
+  @Test
+  public void simple() throws Exception {
+    var xpath = XPath.create(null, "A");
+    assertEquals("//A", xpath.getXPath());
+  }
+
+  // comparisons
+  @Test
+  public void eq() throws Exception {
+    var xpath = XPath.create(null, "A").eq("attr", 42);
+    assertEquals("//A[attr = 42]", xpath.getXPath());
+  }
+
+  @Test
+  public void notEq() throws Exception {
+    var xpath = XPath.create(null, "A").notEq("attr", 42);
+    assertEquals("//A[attr != 42]", xpath.getXPath());
+  }
+
+  @Test
+  public void gt() throws Exception {
+    var xpath = XPath.create(null, "A").gt("attr", 42);
+    assertEquals("//A[attr > 42]", xpath.getXPath());
+  }
+
+  @Test
+  public void gte() throws Exception {
+    var xpath = XPath.create(null, "A").gte("attr", 42);
+    assertEquals("//A[attr >= 42]", xpath.getXPath());
+  }
+
+  @Test
+  public void lt() throws Exception {
+    var xpath = XPath.create(null, "A").lt("attr", 42);
+    assertEquals("//A[attr < 42]", xpath.getXPath());
+  }
+
+  @Test
+  public void lte() throws Exception {
+    var xpath = XPath.create(null, "A").lte("attr", 42);
+    assertEquals("//A[attr <= 42]", xpath.getXPath());
+  }
+
+  // contains, startsWith, endsWith
+  @Test
+  public void contains() throws Exception {
+    var xpath = XPath.create(null, "A").contains("attr", "abc");
+    assertEquals("//A[ contains(attr,'abc') ]", xpath.getXPath());
+  }
+
+  @Test
+  public void startsWith() throws Exception {
+    var xpath = XPath.create(null, "A").startsWith("attr", "abc");
+    assertEquals("//A[ starts-with(attr,'abc') ]", xpath.getXPath());
+  }
+
+  @Test
+  public void endsWith() throws Exception {
+    var xpath = XPath.create(null, "A").endsWith("attr", "abc");
+    assertEquals("//A[ ends-with(attr,'abc') ]", xpath.getXPath());
+  }
+
+  // test classes
+  private static class TestIdentifier implements IMendixIdentifier {
+    private final long id;
+
+    public TestIdentifier(long id) {
+      this.id = id;
+    }
+
+    @Override
+    public String getObjectType() {
+      throw new UnsupportedOperationException("Unimplemented method 'getObjectType'");
+    }
+
+    @Override
+    public long toLong() {
+      return id;
+    }
+
+    @Override
+    public short getEntityId() {
+      throw new UnsupportedOperationException("Unimplemented method 'getEntityId'");
+    }
+
+    @Override
+    public IMendixObject getObject() {
+      throw new UnsupportedOperationException("Unimplemented method 'getObject'");
+    }
+
+    @Override
+    public void setObject(IMendixObject object) {
+      throw new UnsupportedOperationException("Unimplemented method 'setObject'");
+    }
+
+    public TestIdentifier clone() {
+      return new TestIdentifier(id);
+    }
+  }
+
+  private static class TestObject implements IMendixObject {
+    private final IMendixIdentifier id;
+
+    public TestObject(IMendixIdentifier id) {
+      this.id = id;
+    }
+
+    @Override
+    public Map<String, ? extends IMendixObjectMember<?>> getMembers(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'getMembers'");
+    }
+
+    @Override
+    public List<? extends IMendixObjectMember<?>> getChangedMembers(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'getChangedMembers'");
+    }
+
+    @Override
+    public List<? extends MendixObjectReference> getReferences(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'getReferences'");
+    }
+
+    @Override
+    public List<? extends MendixObjectReferenceSet> getReferenceSets(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'getReferenceSets'");
+    }
+
+    @Override
+    public List<? extends IMendixObjectMember<?>> getPrimitives(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'getPrimitives'");
+    }
+
+    @Override
+    public Map<String, ? extends IMendixObjectMember<?>> getVirtualMembers(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'getVirtualMembers'");
+    }
+
+    @Override
+    public boolean isVirtual(IContext context, String name) {
+      throw new UnsupportedOperationException("Unimplemented method 'isVirtual'");
+    }
+
+    @Override
+    public String getType() {
+      throw new UnsupportedOperationException("Unimplemented method 'getType'");
+    }
+
+    @Override
+    public void setValue(IContext context, String memberName, Object value) {
+      throw new UnsupportedOperationException("Unimplemented method 'setValue'");
+    }
+
+    @Override
+    public <T> T getValue(IContext context, String memberName) {
+      throw new UnsupportedOperationException("Unimplemented method 'getValue'");
+    }
+
+    @Override
+    public boolean hasMember(String memberName) {
+      throw new UnsupportedOperationException("Unimplemented method 'hasMember'");
+    }
+
+    @Override
+    public IMendixObjectMember<?> getMember(IContext context, String memberName) {
+      throw new UnsupportedOperationException("Unimplemented method 'getMember'");
+    }
+
+    @Override
+    public IMendixIdentifier getId() {
+      return id;
+    }
+
+    @Override
+    public ObjectState getState() {
+      throw new UnsupportedOperationException("Unimplemented method 'getState'");
+    }
+
+    @Override
+    public boolean isChanged() {
+      throw new UnsupportedOperationException("Unimplemented method 'isChanged'");
+    }
+
+    @Override
+    public boolean hasChangedByAttribute() {
+      throw new UnsupportedOperationException("Unimplemented method 'hasChangedByAttribute'");
+    }
+
+    @Override
+    public boolean hasChangedDateAttribute() {
+      throw new UnsupportedOperationException("Unimplemented method 'hasChangedDateAttribute'");
+    }
+
+    @Override
+    public boolean hasOwnerAttribute() {
+      throw new UnsupportedOperationException("Unimplemented method 'hasOwnerAttribute'");
+    }
+
+    @Override
+    public IMendixIdentifier getChangedBy(IContext context) throws CoreException {
+      throw new UnsupportedOperationException("Unimplemented method 'getChangedBy'");
+    }
+
+    @Override
+    public Date getChangedDate(IContext context) throws CoreException {
+      throw new UnsupportedOperationException("Unimplemented method 'getChangedDate'");
+    }
+
+    @Override
+    public IMendixIdentifier getOwner(IContext context) throws CoreException {
+      throw new UnsupportedOperationException("Unimplemented method 'getOwner'");
+    }
+
+    @Override
+    public boolean hasCreatedDateAttribute() {
+      throw new UnsupportedOperationException("Unimplemented method 'hasCreatedDateAttribute'");
+    }
+
+    @Override
+    public Date getCreatedDate(IContext context) throws CoreException {
+      throw new UnsupportedOperationException("Unimplemented method 'getCreatedDate'");
+    }
+
+    @Override
+    public boolean hasNullValues(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'hasNullValues'");
+    }
+
+    @Override
+    public IMetaObject getMetaObject() {
+      throw new UnsupportedOperationException("Unimplemented method 'getMetaObject'");
+    }
+
+    @Override
+    public boolean hasDeleteRights(IContext context) {
+      throw new UnsupportedOperationException("Unimplemented method 'hasDeleteRights'");
+    }
+
+    @Override
+    public boolean isNew() {
+      throw new UnsupportedOperationException("Unimplemented method 'isNew'");
+    }
+
+    public TestObject clone() {
+      return new TestObject(id);
+    }
+  }
+
+  private static class TestProxy {
+    private final IMendixObject obj;
+
+    public TestProxy(IMendixObject obj) {
+      this.obj = obj;
+    }
+
+    public IMendixObject getMendixObject() {
+      return obj;
+    }
+  }
+
+}

--- a/src/test/communitycommons/XPathTest.java
+++ b/src/test/communitycommons/XPathTest.java
@@ -53,36 +53,48 @@ public class XPathTest {
   public void eq() throws Exception {
     var xpath = XPath.create(null, "A").eq("attr", 42);
     assertEquals("//A[attr = 42]", xpath.getXPath());
+    var xpathPath = XPath.create(null, "A").eq("attr1", "attr2", "attr3", 42);
+    assertEquals("//A[attr1/attr2/attr3 = 42]", xpathPath.getXPath());
   }
 
   @Test
   public void notEq() throws Exception {
     var xpath = XPath.create(null, "A").notEq("attr", 42);
     assertEquals("//A[attr != 42]", xpath.getXPath());
+    var xpathPath = XPath.create(null, "A").notEq("attr1", "attr2", "attr3", 42);
+    assertEquals("//A[attr1/attr2/attr3 != 42]", xpathPath.getXPath());
   }
 
   @Test
   public void gt() throws Exception {
     var xpath = XPath.create(null, "A").gt("attr", 42);
     assertEquals("//A[attr > 42]", xpath.getXPath());
+    var xpathPath = XPath.create(null, "A").gt("attr1", "attr2", "attr3", 42);
+    assertEquals("//A[attr1/attr2/attr3 > 42]", xpathPath.getXPath());
   }
 
   @Test
   public void gte() throws Exception {
     var xpath = XPath.create(null, "A").gte("attr", 42);
     assertEquals("//A[attr >= 42]", xpath.getXPath());
+    var xpathPath = XPath.create(null, "A").gte("attr1", "attr2", "attr3", 42);
+    assertEquals("//A[attr1/attr2/attr3 >= 42]", xpathPath.getXPath());
   }
 
   @Test
   public void lt() throws Exception {
     var xpath = XPath.create(null, "A").lt("attr", 42);
     assertEquals("//A[attr < 42]", xpath.getXPath());
+    var xpathPath = XPath.create(null, "A").lt("attr1", "attr2", "attr3", 42);
+    assertEquals("//A[attr1/attr2/attr3 < 42]", xpathPath.getXPath());
   }
 
   @Test
   public void lte() throws Exception {
     var xpath = XPath.create(null, "A").lte("attr", 42);
     assertEquals("//A[attr <= 42]", xpath.getXPath());
+    var xpathPath = XPath.create(null, "A").lte("attr1", "attr2", "attr3", 42);
+    assertEquals("//A[attr1/attr2/attr3 <= 42]", xpathPath.getXPath());
   }
 
   // contains, startsWith, endsWith

--- a/src/test/communitycommons/XPathTest.java
+++ b/src/test/communitycommons/XPathTest.java
@@ -53,48 +53,48 @@ public class XPathTest {
   public void eq() throws Exception {
     var xpath = XPath.create(null, "A").eq("attr", 42);
     assertEquals("//A[attr = 42]", xpath.getXPath());
-    var xpathPath = XPath.create(null, "A").eq("attr1", "attr2", "attr3", 42);
-    assertEquals("//A[attr1/attr2/attr3 = 42]", xpathPath.getXPath());
+    var xpathPath = XPath.create(null, "A").eq("assoc", "entity", "attr", 42);
+    assertEquals("//A[assoc/entity/attr = 42]", xpathPath.getXPath());
   }
 
   @Test
   public void notEq() throws Exception {
     var xpath = XPath.create(null, "A").notEq("attr", 42);
     assertEquals("//A[attr != 42]", xpath.getXPath());
-    var xpathPath = XPath.create(null, "A").notEq("attr1", "attr2", "attr3", 42);
-    assertEquals("//A[attr1/attr2/attr3 != 42]", xpathPath.getXPath());
+    var xpathPath = XPath.create(null, "A").notEq("assoc", "entity", "attr", 42);
+    assertEquals("//A[assoc/entity/attr != 42]", xpathPath.getXPath());
   }
 
   @Test
   public void gt() throws Exception {
     var xpath = XPath.create(null, "A").gt("attr", 42);
     assertEquals("//A[attr > 42]", xpath.getXPath());
-    var xpathPath = XPath.create(null, "A").gt("attr1", "attr2", "attr3", 42);
-    assertEquals("//A[attr1/attr2/attr3 > 42]", xpathPath.getXPath());
+    var xpathPath = XPath.create(null, "A").gt("assoc", "entity", "attr", 42);
+    assertEquals("//A[assoc/entity/attr > 42]", xpathPath.getXPath());
   }
 
   @Test
   public void gte() throws Exception {
     var xpath = XPath.create(null, "A").gte("attr", 42);
     assertEquals("//A[attr >= 42]", xpath.getXPath());
-    var xpathPath = XPath.create(null, "A").gte("attr1", "attr2", "attr3", 42);
-    assertEquals("//A[attr1/attr2/attr3 >= 42]", xpathPath.getXPath());
+    var xpathPath = XPath.create(null, "A").gte("assoc", "entity", "attr", 42);
+    assertEquals("//A[assoc/entity/attr >= 42]", xpathPath.getXPath());
   }
 
   @Test
   public void lt() throws Exception {
     var xpath = XPath.create(null, "A").lt("attr", 42);
     assertEquals("//A[attr < 42]", xpath.getXPath());
-    var xpathPath = XPath.create(null, "A").lt("attr1", "attr2", "attr3", 42);
-    assertEquals("//A[attr1/attr2/attr3 < 42]", xpathPath.getXPath());
+    var xpathPath = XPath.create(null, "A").lt("assoc", "entity", "attr", 42);
+    assertEquals("//A[assoc/entity/attr < 42]", xpathPath.getXPath());
   }
 
   @Test
   public void lte() throws Exception {
     var xpath = XPath.create(null, "A").lte("attr", 42);
     assertEquals("//A[attr <= 42]", xpath.getXPath());
-    var xpathPath = XPath.create(null, "A").lte("attr1", "attr2", "attr3", 42);
-    assertEquals("//A[attr1/attr2/attr3 <= 42]", xpathPath.getXPath());
+    var xpathPath = XPath.create(null, "A").lte("assoc", "entity", "attr", 42);
+    assertEquals("//A[assoc/entity/attr <= 42]", xpathPath.getXPath());
   }
 
   // contains, startsWith, endsWith

--- a/src/test/communitycommons/XPathTest.java
+++ b/src/test/communitycommons/XPathTest.java
@@ -19,328 +19,328 @@ import com.mendix.systemwideinterfaces.core.meta.IMetaObject;
 
 public class XPathTest {
 
-  @Test
-  public void valueToXPathValue() throws Exception {
-    assertEquals(XPath.NULL, XPath.valueToXPathValue(null));
-    assertEquals("42", XPath.valueToXPathValue(42));
-    assertEquals("42.42", XPath.valueToXPathValue(42.42));
-    assertEquals("'string'", XPath.valueToXPathValue("string"));
-    assertEquals("true()", XPath.valueToXPathValue(true));
-    assertEquals("false()", XPath.valueToXPathValue(false));
-
-    var d = new Date();
-    assertEquals("" + d.getTime(), XPath.valueToXPathValue(d));
-
-    var id = new TestIdentifier(123);
-    assertEquals("'123'", XPath.valueToXPathValue(id));
-
-    var obj = new TestObject(id);
-    assertEquals("'123'", XPath.valueToXPathValue(obj));
-
-    var proxy = new TestProxy(obj);
-    assertEquals("'123'", XPath.valueToXPathValue(proxy));
-  }
-
-  // XPath
-  @Test
-  public void simple() throws Exception {
-    var xpath = XPath.create(null, "A");
-    assertEquals("//A", xpath.getXPath());
-  }
-
-  // comparisons
-  @Test
-  public void eq() throws Exception {
-    var xpath = XPath.create(null, "A").eq("attr", 42);
-    assertEquals("//A[attr = 42]", xpath.getXPath());
-
-    var xpathPath = XPath.create(null, "A").eq("assoc", "entity", "attr", 42);
-    assertEquals("//A[assoc/entity/attr = 42]", xpathPath.getXPath());
-
-    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
-      XPath.create(null, "A").eq("assoc", "attr", 42);
-    });
-  }
-
-  @Test
-  public void notEq() throws Exception {
-    var xpath = XPath.create(null, "A").notEq("attr", 42);
-    assertEquals("//A[attr != 42]", xpath.getXPath());
-
-    var xpathPath = XPath.create(null, "A").notEq("assoc", "entity", "attr", 42);
-    assertEquals("//A[assoc/entity/attr != 42]", xpathPath.getXPath());
-
-    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
-      XPath.create(null, "A").notEq("assoc", "attr", 42);
-    });
-  }
-
-  @Test
-  public void gt() throws Exception {
-    var xpath = XPath.create(null, "A").gt("attr", 42);
-    assertEquals("//A[attr > 42]", xpath.getXPath());
-
-    var xpathPath = XPath.create(null, "A").gt("assoc", "entity", "attr", 42);
-    assertEquals("//A[assoc/entity/attr > 42]", xpathPath.getXPath());
-
-    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
-      XPath.create(null, "A").gt("assoc", "attr", 42);
-    });
-  }
-
-  @Test
-  public void gte() throws Exception {
-    var xpath = XPath.create(null, "A").gte("attr", 42);
-    assertEquals("//A[attr >= 42]", xpath.getXPath());
-
-    var xpathPath = XPath.create(null, "A").gte("assoc", "entity", "attr", 42);
-    assertEquals("//A[assoc/entity/attr >= 42]", xpathPath.getXPath());
-
-    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
-      XPath.create(null, "A").gte("assoc", "attr", 42);
-    });
-  }
-
-  @Test
-  public void lt() throws Exception {
-    var xpath = XPath.create(null, "A").lt("attr", 42);
-    assertEquals("//A[attr < 42]", xpath.getXPath());
-
-    var xpathPath = XPath.create(null, "A").lt("assoc", "entity", "attr", 42);
-    assertEquals("//A[assoc/entity/attr < 42]", xpathPath.getXPath());
-
-    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
-      XPath.create(null, "A").lt("assoc", "attr", 42);
-    });
-  }
-
-  @Test
-  public void lte() throws Exception {
-    var xpath = XPath.create(null, "A").lte("attr", 42);
-    assertEquals("//A[attr <= 42]", xpath.getXPath());
-
-    var xpathPath = XPath.create(null, "A").lte("assoc", "entity", "attr", 42);
-    assertEquals("//A[assoc/entity/attr <= 42]", xpathPath.getXPath());
-
-    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
-      XPath.create(null, "A").lte("assoc", "attr", 42);
-    });
-  }
-
-  // contains, startsWith, endsWith
-  @Test
-  public void contains() throws Exception {
-    var xpath = XPath.create(null, "A").contains("attr", "abc");
-    assertEquals("//A[ contains(attr,'abc') ]", xpath.getXPath());
-  }
-
-  @Test
-  public void startsWith() throws Exception {
-    var xpath = XPath.create(null, "A").startsWith("attr", "abc");
-    assertEquals("//A[ starts-with(attr,'abc') ]", xpath.getXPath());
-  }
-
-  @Test
-  public void endsWith() throws Exception {
-    var xpath = XPath.create(null, "A").endsWith("attr", "abc");
-    assertEquals("//A[ ends-with(attr,'abc') ]", xpath.getXPath());
-  }
-
-  // test classes
-  private static class TestIdentifier implements IMendixIdentifier {
-    private final long id;
-
-    public TestIdentifier(long id) {
-      this.id = id;
-    }
-
-    @Override
-    public String getObjectType() {
-      throw new UnsupportedOperationException("Unimplemented method 'getObjectType'");
-    }
-
-    @Override
-    public long toLong() {
-      return id;
-    }
-
-    @Override
-    public short getEntityId() {
-      throw new UnsupportedOperationException("Unimplemented method 'getEntityId'");
-    }
-
-    @Override
-    public IMendixObject getObject() {
-      throw new UnsupportedOperationException("Unimplemented method 'getObject'");
-    }
-
-    @Override
-    public void setObject(IMendixObject object) {
-      throw new UnsupportedOperationException("Unimplemented method 'setObject'");
-    }
-
-    public TestIdentifier clone() {
-      return new TestIdentifier(id);
-    }
-  }
-
-  private static class TestObject implements IMendixObject {
-    private final IMendixIdentifier id;
-
-    public TestObject(IMendixIdentifier id) {
-      this.id = id;
-    }
-
-    @Override
-    public Map<String, ? extends IMendixObjectMember<?>> getMembers(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'getMembers'");
-    }
-
-    @Override
-    public List<? extends IMendixObjectMember<?>> getChangedMembers(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'getChangedMembers'");
-    }
-
-    @Override
-    public List<? extends MendixObjectReference> getReferences(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'getReferences'");
-    }
-
-    @Override
-    public List<? extends MendixObjectReferenceSet> getReferenceSets(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'getReferenceSets'");
-    }
-
-    @Override
-    public List<? extends IMendixObjectMember<?>> getPrimitives(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'getPrimitives'");
-    }
-
-    @Override
-    public Map<String, ? extends IMendixObjectMember<?>> getVirtualMembers(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'getVirtualMembers'");
-    }
-
-    @Override
-    public boolean isVirtual(IContext context, String name) {
-      throw new UnsupportedOperationException("Unimplemented method 'isVirtual'");
-    }
-
-    @Override
-    public String getType() {
-      throw new UnsupportedOperationException("Unimplemented method 'getType'");
-    }
-
-    @Override
-    public void setValue(IContext context, String memberName, Object value) {
-      throw new UnsupportedOperationException("Unimplemented method 'setValue'");
-    }
-
-    @Override
-    public <T> T getValue(IContext context, String memberName) {
-      throw new UnsupportedOperationException("Unimplemented method 'getValue'");
-    }
-
-    @Override
-    public boolean hasMember(String memberName) {
-      throw new UnsupportedOperationException("Unimplemented method 'hasMember'");
-    }
-
-    @Override
-    public IMendixObjectMember<?> getMember(IContext context, String memberName) {
-      throw new UnsupportedOperationException("Unimplemented method 'getMember'");
-    }
-
-    @Override
-    public IMendixIdentifier getId() {
-      return id;
-    }
-
-    @Override
-    public ObjectState getState() {
-      throw new UnsupportedOperationException("Unimplemented method 'getState'");
-    }
-
-    @Override
-    public boolean isChanged() {
-      throw new UnsupportedOperationException("Unimplemented method 'isChanged'");
-    }
-
-    @Override
-    public boolean hasChangedByAttribute() {
-      throw new UnsupportedOperationException("Unimplemented method 'hasChangedByAttribute'");
-    }
-
-    @Override
-    public boolean hasChangedDateAttribute() {
-      throw new UnsupportedOperationException("Unimplemented method 'hasChangedDateAttribute'");
-    }
-
-    @Override
-    public boolean hasOwnerAttribute() {
-      throw new UnsupportedOperationException("Unimplemented method 'hasOwnerAttribute'");
-    }
-
-    @Override
-    public IMendixIdentifier getChangedBy(IContext context) throws CoreException {
-      throw new UnsupportedOperationException("Unimplemented method 'getChangedBy'");
-    }
-
-    @Override
-    public Date getChangedDate(IContext context) throws CoreException {
-      throw new UnsupportedOperationException("Unimplemented method 'getChangedDate'");
-    }
-
-    @Override
-    public IMendixIdentifier getOwner(IContext context) throws CoreException {
-      throw new UnsupportedOperationException("Unimplemented method 'getOwner'");
-    }
-
-    @Override
-    public boolean hasCreatedDateAttribute() {
-      throw new UnsupportedOperationException("Unimplemented method 'hasCreatedDateAttribute'");
-    }
-
-    @Override
-    public Date getCreatedDate(IContext context) throws CoreException {
-      throw new UnsupportedOperationException("Unimplemented method 'getCreatedDate'");
-    }
-
-    @Override
-    public boolean hasNullValues(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'hasNullValues'");
-    }
-
-    @Override
-    public IMetaObject getMetaObject() {
-      throw new UnsupportedOperationException("Unimplemented method 'getMetaObject'");
-    }
-
-    @Override
-    public boolean hasDeleteRights(IContext context) {
-      throw new UnsupportedOperationException("Unimplemented method 'hasDeleteRights'");
-    }
-
-    @Override
-    public boolean isNew() {
-      throw new UnsupportedOperationException("Unimplemented method 'isNew'");
-    }
-
-    public TestObject clone() {
-      return new TestObject(id);
-    }
-  }
-
-  private static class TestProxy {
-    private final IMendixObject obj;
-
-    public TestProxy(IMendixObject obj) {
-      this.obj = obj;
-    }
-
-    public IMendixObject getMendixObject() {
-      return obj;
-    }
-  }
+	@Test
+	public void valueToXPathValue() throws Exception {
+		assertEquals(XPath.NULL, XPath.valueToXPathValue(null));
+		assertEquals("42", XPath.valueToXPathValue(42));
+		assertEquals("42.42", XPath.valueToXPathValue(42.42));
+		assertEquals("'string'", XPath.valueToXPathValue("string"));
+		assertEquals("true()", XPath.valueToXPathValue(true));
+		assertEquals("false()", XPath.valueToXPathValue(false));
+
+		var d = new Date();
+		assertEquals("" + d.getTime(), XPath.valueToXPathValue(d));
+
+		var id = new TestIdentifier(123);
+		assertEquals("'123'", XPath.valueToXPathValue(id));
+
+		var obj = new TestObject(id);
+		assertEquals("'123'", XPath.valueToXPathValue(obj));
+
+		var proxy = new TestProxy(obj);
+		assertEquals("'123'", XPath.valueToXPathValue(proxy));
+	}
+
+	// XPath
+	@Test
+	public void simple() throws Exception {
+		var xpath = XPath.create(null, "A");
+		assertEquals("//A", xpath.getXPath());
+	}
+
+	// comparisons
+	@Test
+	public void eq() throws Exception {
+		var xpath = XPath.create(null, "A").eq("attr", 42);
+		assertEquals("//A[attr = 42]", xpath.getXPath());
+
+		var xpathPath = XPath.create(null, "A").eq("assoc", "entity", "attr", 42);
+		assertEquals("//A[assoc/entity/attr = 42]", xpathPath.getXPath());
+
+		assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+			XPath.create(null, "A").eq("assoc", "attr", 42);
+		});
+	}
+
+	@Test
+	public void notEq() throws Exception {
+		var xpath = XPath.create(null, "A").notEq("attr", 42);
+		assertEquals("//A[attr != 42]", xpath.getXPath());
+
+		var xpathPath = XPath.create(null, "A").notEq("assoc", "entity", "attr", 42);
+		assertEquals("//A[assoc/entity/attr != 42]", xpathPath.getXPath());
+
+		assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+			XPath.create(null, "A").notEq("assoc", "attr", 42);
+		});
+	}
+
+	@Test
+	public void gt() throws Exception {
+		var xpath = XPath.create(null, "A").gt("attr", 42);
+		assertEquals("//A[attr > 42]", xpath.getXPath());
+
+		var xpathPath = XPath.create(null, "A").gt("assoc", "entity", "attr", 42);
+		assertEquals("//A[assoc/entity/attr > 42]", xpathPath.getXPath());
+
+		assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+			XPath.create(null, "A").gt("assoc", "attr", 42);
+		});
+	}
+
+	@Test
+	public void gte() throws Exception {
+		var xpath = XPath.create(null, "A").gte("attr", 42);
+		assertEquals("//A[attr >= 42]", xpath.getXPath());
+
+		var xpathPath = XPath.create(null, "A").gte("assoc", "entity", "attr", 42);
+		assertEquals("//A[assoc/entity/attr >= 42]", xpathPath.getXPath());
+
+		assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+			XPath.create(null, "A").gte("assoc", "attr", 42);
+		});
+	}
+
+	@Test
+	public void lt() throws Exception {
+		var xpath = XPath.create(null, "A").lt("attr", 42);
+		assertEquals("//A[attr < 42]", xpath.getXPath());
+
+		var xpathPath = XPath.create(null, "A").lt("assoc", "entity", "attr", 42);
+		assertEquals("//A[assoc/entity/attr < 42]", xpathPath.getXPath());
+
+		assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+			XPath.create(null, "A").lt("assoc", "attr", 42);
+		});
+	}
+
+	@Test
+	public void lte() throws Exception {
+		var xpath = XPath.create(null, "A").lte("attr", 42);
+		assertEquals("//A[attr <= 42]", xpath.getXPath());
+
+		var xpathPath = XPath.create(null, "A").lte("assoc", "entity", "attr", 42);
+		assertEquals("//A[assoc/entity/attr <= 42]", xpathPath.getXPath());
+
+		assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+			XPath.create(null, "A").lte("assoc", "attr", 42);
+		});
+	}
+
+	// contains, startsWith, endsWith
+	@Test
+	public void contains() throws Exception {
+		var xpath = XPath.create(null, "A").contains("attr", "abc");
+		assertEquals("//A[ contains(attr,'abc') ]", xpath.getXPath());
+	}
+
+	@Test
+	public void startsWith() throws Exception {
+		var xpath = XPath.create(null, "A").startsWith("attr", "abc");
+		assertEquals("//A[ starts-with(attr,'abc') ]", xpath.getXPath());
+	}
+
+	@Test
+	public void endsWith() throws Exception {
+		var xpath = XPath.create(null, "A").endsWith("attr", "abc");
+		assertEquals("//A[ ends-with(attr,'abc') ]", xpath.getXPath());
+	}
+
+	// test classes
+	private static class TestIdentifier implements IMendixIdentifier {
+		private final long id;
+
+		public TestIdentifier(long id) {
+			this.id = id;
+		}
+
+		@Override
+		public String getObjectType() {
+			throw new UnsupportedOperationException("Unimplemented method 'getObjectType'");
+		}
+
+		@Override
+		public long toLong() {
+			return id;
+		}
+
+		@Override
+		public short getEntityId() {
+			throw new UnsupportedOperationException("Unimplemented method 'getEntityId'");
+		}
+
+		@Override
+		public IMendixObject getObject() {
+			throw new UnsupportedOperationException("Unimplemented method 'getObject'");
+		}
+
+		@Override
+		public void setObject(IMendixObject object) {
+			throw new UnsupportedOperationException("Unimplemented method 'setObject'");
+		}
+
+		public TestIdentifier clone() {
+			return new TestIdentifier(id);
+		}
+	}
+
+	private static class TestObject implements IMendixObject {
+		private final IMendixIdentifier id;
+
+		public TestObject(IMendixIdentifier id) {
+			this.id = id;
+		}
+
+		@Override
+		public Map<String, ? extends IMendixObjectMember<?>> getMembers(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'getMembers'");
+		}
+
+		@Override
+		public List<? extends IMendixObjectMember<?>> getChangedMembers(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'getChangedMembers'");
+		}
+
+		@Override
+		public List<? extends MendixObjectReference> getReferences(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'getReferences'");
+		}
+
+		@Override
+		public List<? extends MendixObjectReferenceSet> getReferenceSets(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'getReferenceSets'");
+		}
+
+		@Override
+		public List<? extends IMendixObjectMember<?>> getPrimitives(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'getPrimitives'");
+		}
+
+		@Override
+		public Map<String, ? extends IMendixObjectMember<?>> getVirtualMembers(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'getVirtualMembers'");
+		}
+
+		@Override
+		public boolean isVirtual(IContext context, String name) {
+			throw new UnsupportedOperationException("Unimplemented method 'isVirtual'");
+		}
+
+		@Override
+		public String getType() {
+			throw new UnsupportedOperationException("Unimplemented method 'getType'");
+		}
+
+		@Override
+		public void setValue(IContext context, String memberName, Object value) {
+			throw new UnsupportedOperationException("Unimplemented method 'setValue'");
+		}
+
+		@Override
+		public <T> T getValue(IContext context, String memberName) {
+			throw new UnsupportedOperationException("Unimplemented method 'getValue'");
+		}
+
+		@Override
+		public boolean hasMember(String memberName) {
+			throw new UnsupportedOperationException("Unimplemented method 'hasMember'");
+		}
+
+		@Override
+		public IMendixObjectMember<?> getMember(IContext context, String memberName) {
+			throw new UnsupportedOperationException("Unimplemented method 'getMember'");
+		}
+
+		@Override
+		public IMendixIdentifier getId() {
+			return id;
+		}
+
+		@Override
+		public ObjectState getState() {
+			throw new UnsupportedOperationException("Unimplemented method 'getState'");
+		}
+
+		@Override
+		public boolean isChanged() {
+			throw new UnsupportedOperationException("Unimplemented method 'isChanged'");
+		}
+
+		@Override
+		public boolean hasChangedByAttribute() {
+			throw new UnsupportedOperationException("Unimplemented method 'hasChangedByAttribute'");
+		}
+
+		@Override
+		public boolean hasChangedDateAttribute() {
+			throw new UnsupportedOperationException("Unimplemented method 'hasChangedDateAttribute'");
+		}
+
+		@Override
+		public boolean hasOwnerAttribute() {
+			throw new UnsupportedOperationException("Unimplemented method 'hasOwnerAttribute'");
+		}
+
+		@Override
+		public IMendixIdentifier getChangedBy(IContext context) throws CoreException {
+			throw new UnsupportedOperationException("Unimplemented method 'getChangedBy'");
+		}
+
+		@Override
+		public Date getChangedDate(IContext context) throws CoreException {
+			throw new UnsupportedOperationException("Unimplemented method 'getChangedDate'");
+		}
+
+		@Override
+		public IMendixIdentifier getOwner(IContext context) throws CoreException {
+			throw new UnsupportedOperationException("Unimplemented method 'getOwner'");
+		}
+
+		@Override
+		public boolean hasCreatedDateAttribute() {
+			throw new UnsupportedOperationException("Unimplemented method 'hasCreatedDateAttribute'");
+		}
+
+		@Override
+		public Date getCreatedDate(IContext context) throws CoreException {
+			throw new UnsupportedOperationException("Unimplemented method 'getCreatedDate'");
+		}
+
+		@Override
+		public boolean hasNullValues(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'hasNullValues'");
+		}
+
+		@Override
+		public IMetaObject getMetaObject() {
+			throw new UnsupportedOperationException("Unimplemented method 'getMetaObject'");
+		}
+
+		@Override
+		public boolean hasDeleteRights(IContext context) {
+			throw new UnsupportedOperationException("Unimplemented method 'hasDeleteRights'");
+		}
+
+		@Override
+		public boolean isNew() {
+			throw new UnsupportedOperationException("Unimplemented method 'isNew'");
+		}
+
+		public TestObject clone() {
+			return new TestObject(id);
+		}
+	}
+
+	private static class TestProxy {
+		private final IMendixObject obj;
+
+		public TestProxy(IMendixObject obj) {
+			this.obj = obj;
+		}
+
+		public IMendixObject getMendixObject() {
+			return obj;
+		}
+	}
 
 }

--- a/src/test/communitycommons/XPathTest.java
+++ b/src/test/communitycommons/XPathTest.java
@@ -1,8 +1,8 @@
 package communitycommons;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Date;
 import java.util.List;
@@ -53,48 +53,78 @@ public class XPathTest {
   public void eq() throws Exception {
     var xpath = XPath.create(null, "A").eq("attr", 42);
     assertEquals("//A[attr = 42]", xpath.getXPath());
+
     var xpathPath = XPath.create(null, "A").eq("assoc", "entity", "attr", 42);
     assertEquals("//A[assoc/entity/attr = 42]", xpathPath.getXPath());
+
+    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+      XPath.create(null, "A").eq("assoc", "attr", 42);
+    });
   }
 
   @Test
   public void notEq() throws Exception {
     var xpath = XPath.create(null, "A").notEq("attr", 42);
     assertEquals("//A[attr != 42]", xpath.getXPath());
+
     var xpathPath = XPath.create(null, "A").notEq("assoc", "entity", "attr", 42);
     assertEquals("//A[assoc/entity/attr != 42]", xpathPath.getXPath());
+
+    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+      XPath.create(null, "A").notEq("assoc", "attr", 42);
+    });
   }
 
   @Test
   public void gt() throws Exception {
     var xpath = XPath.create(null, "A").gt("attr", 42);
     assertEquals("//A[attr > 42]", xpath.getXPath());
+
     var xpathPath = XPath.create(null, "A").gt("assoc", "entity", "attr", 42);
     assertEquals("//A[assoc/entity/attr > 42]", xpathPath.getXPath());
+
+    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+      XPath.create(null, "A").gt("assoc", "attr", 42);
+    });
   }
 
   @Test
   public void gte() throws Exception {
     var xpath = XPath.create(null, "A").gte("attr", 42);
     assertEquals("//A[attr >= 42]", xpath.getXPath());
+
     var xpathPath = XPath.create(null, "A").gte("assoc", "entity", "attr", 42);
     assertEquals("//A[assoc/entity/attr >= 42]", xpathPath.getXPath());
+
+    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+      XPath.create(null, "A").gte("assoc", "attr", 42);
+    });
   }
 
   @Test
   public void lt() throws Exception {
     var xpath = XPath.create(null, "A").lt("attr", 42);
     assertEquals("//A[attr < 42]", xpath.getXPath());
+
     var xpathPath = XPath.create(null, "A").lt("assoc", "entity", "attr", 42);
     assertEquals("//A[assoc/entity/attr < 42]", xpathPath.getXPath());
+
+    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+      XPath.create(null, "A").lt("assoc", "attr", 42);
+    });
   }
 
   @Test
   public void lte() throws Exception {
     var xpath = XPath.create(null, "A").lte("attr", 42);
     assertEquals("//A[attr <= 42]", xpath.getXPath());
+
     var xpathPath = XPath.create(null, "A").lte("assoc", "entity", "attr", 42);
     assertEquals("//A[assoc/entity/attr <= 42]", xpathPath.getXPath());
+
+    assertThrows("Expected an even number of xpath path parts", java.lang.IllegalArgumentException.class, () -> {
+      XPath.create(null, "A").lte("assoc", "attr", 42);
+    });
   }
 
   // contains, startsWith, endsWith

--- a/src/test/communitycommons/XPathTest.java
+++ b/src/test/communitycommons/XPathTest.java
@@ -21,7 +21,7 @@ public class XPathTest {
 
   @Test
   public void valueToXPathValue() throws Exception {
-    assertEquals("NULL", XPath.valueToXPathValue(null));
+    assertEquals(XPath.NULL, XPath.valueToXPathValue(null));
     assertEquals("42", XPath.valueToXPathValue(42));
     assertEquals("42.42", XPath.valueToXPathValue(42.42));
     assertEquals("'string'", XPath.valueToXPathValue("string"));


### PR DESCRIPTION
This PR:
- Cleans up XPath.java
- Adds `startsWith`, `endsWith`, `gte`, `lt` and `lte`
- Fixes `gt`, which was using `>=` instead of the correct `>`
- Update Guava to 32.0.1