### PR TITLE
[RUN-3602] Generate migration file when exporting module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
 
 plugins {
     id 'java'
-    id 'com.mendix.gradle.publish-module-plugin' version '1.12'
+    id 'com.mendix.gradle.publish-module-plugin' version '1.13'
     id 'net.researchgate.release' version '2.8.1'
 }
 
@@ -23,6 +23,7 @@ mxMarketplace {
     moduleLicense = 'Apache V2'
     appDirectory = "src/CommunityCommons"
     versionPathPrefix = "_Version " // the path prefix within the module to the version folder
+    createMigrationFile = true
 }
 
 def userLibDir = "$projectDir/src/CommunityCommons/userlib"
@@ -33,6 +34,12 @@ repositories {
     }
     maven {
         url 'https://nexus.rnd.mendix.com/repository/maven-hosted/'
+    }
+}
+
+configurations {
+    implementation {
+        canBeResolved = true
     }
 }
 
@@ -86,12 +93,6 @@ task copyAllToUserlib(type: Copy) {
     eachFile { fileCopyDetails -> new File(destinationDir, "${fileCopyDetails.name}.${project.name}.RequiredLib").write '' }
 }
 
-task copyRuntimeToUserlib(type: Copy) {
-    from configurations.runtimeClasspath
-    into userLibDir
-    eachFile { fileCopyDetails -> new File(destinationDir, "${fileCopyDetails.name}.${project.name}.RequiredLib").write '' }
-}
-
 tasks.named('mxBuild') {
     dependsOn copyAllToUserlib
 }
@@ -102,10 +103,6 @@ tasks.named('compileJava') {
 
 clean {
     delete "$userLibDir"
-}
-
-tasks.named('exportModule') {
-    dependsOn 'copyRuntimeToUserlib'
 }
 
 release {

--- a/marketplace/release-notes/10.0.2.txt
+++ b/marketplace/release-notes/10.0.2.txt
@@ -1,0 +1,1 @@
+Include a migration file for the Java dependencies.


### PR DESCRIPTION
This MR:
- Modifies the jar-copying tasks to also generate a migration file in the userlib directory
- Update the release plugin to 1.13 and set filterRequiredLibs to false
- Update CommunityCommons to 10.0.2