### PR TITLE
ensure applicationUrl starts with https

### DIFF
--- a/src/CommunityCommons/javasource/communitycommons/Misc.java
+++ b/src/CommunityCommons/javasource/communitycommons/Misc.java
@@ -138,7 +138,8 @@ public class Misc {
 
 	public static String getApplicationURL() {
 		final String applicationURL = UNDER_TEST ? "http://localhost:8080/" : Core.getConfiguration().getApplicationRootUrl();
-		return StringUtils.removeEnd(applicationURL, "/");
+		String modifiedURL = applicationURL.startsWith("https://") ? applicationURL : "https://" + applicationURL;
+		return StringUtils.removeEnd(modifiedURL, "/");
 	}
 
 	public static String getRuntimeVersion() {


### PR DESCRIPTION
The java action GetApplicationURL returns the URL without the prefix `https://`, this breaks the redirect logic of the Mendix OpenID module for Azure SSO (`redirect_uri`, `post_logout_redirect_uri` & location headers)