### PR TITLE
[RUN-4148] Make the implicit conversion explicit

### DIFF
--- a/marketplace/release-notes/10.0.6.txt
+++ b/marketplace/release-notes/10.0.6.txt
@@ -1,0 +1,1 @@
+- We removed "implicit narrowing conversion" which caused a warning to be made by a code scanning tool.

--- a/src/CommunityCommons/javasource/communitycommons/XPath.java
+++ b/src/CommunityCommons/javasource/communitycommons/XPath.java
@@ -528,7 +528,7 @@ public class XPath<T> {
 				break;
 
 			if (loopcount % 5 == 0)
-				sleepamount *= 1.5;
+				sleepamount = (int)(sleepamount * 1.5);
 
 			// not expired, wait a bit
 			if (result == null)


### PR DESCRIPTION
A code scanning tool gives a warning on the implicit conversion. This change is to stop the warning.

![image](https://github.com/mendix/CommunityCommons/assets/4507387/7722fd5d-cb1d-4e86-82b3-52dd8ea21f10)
